### PR TITLE
ci: add govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,6 +1,8 @@
 on: 
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
   schedule:
     - cron: '23 13 * * 1'
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,16 @@
+on: 
+  push:
+    branches: [ master ]
+  schedule:
+    - cron: '23 13 * * 1'
+
+jobs:
+  govulncheck_job:
+    runs-on: ubuntu-latest
+    name: Run govulncheck
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+           go-version-input: 1.21
+           go-package: ./...


### PR DESCRIPTION
Runs `govulncheck` on pushes to master and 01:23 PM on Mondays. This coincides with 08:23 AM Central time. Please feel free to adjust timing or conditions as needed. 