### PR TITLE
ci: added preliminary Gitleaks

### DIFF
--- a/.github/workflows/gitleak.yml
+++ b/.github/workflows/gitleak.yml
@@ -1,0 +1,18 @@
+name: Gitleaks
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}} # This is required for organizations.


### PR DESCRIPTION
This PR adds preliminary support for utilizing Gitleaks to check for secrets. 

A couple of things to note:
1. A GITHUB_TOKEN must be added.
2. We require an organizational license (which is free) from [here](https://gitleaks.io/products.html).

@taigrr, would you be willing to get this setup and completed?

