### PR TITLE
fix(ci): govulncheck uses go.mod and use the correct notation from actions/setup-go

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,12 +13,8 @@ jobs:
     name: Run govulncheck
     steps:
       - uses: actions/checkout@v3
-      - name: Extract Go version
-        run:
-          GO_VERSION=$(grep "^go [0-9]\+\.[0-9]\+\.[0-9]\+" go.mod | awk '{print $2}')
-          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-           go-version-input: ${{ env.GO_VERSION }}
+           go-version-file: 'go.mod'
            go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gogrlx/grlx
 
-go 1.21
+go 1.21.1
 
 require (
 	github.com/djherbis/atime v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gogrlx/grlx
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/djherbis/atime v1.1.0


### PR DESCRIPTION
- Updated to use https://github.com/golang/govulncheck-action/blob/7da72f730e37eeaad891fcff0a532d27ed737cd4/README.md?plain=1#L67
- Revert go.mod to read from the go-version-file instead of custom parsing

Related to #60 