### PR TITLE
Initial grlx file testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ configs/
 etc
 .env
 *.zip
+coverage.out

--- a/cmd/sprout/include.go
+++ b/cmd/sprout/include.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	_ "github.com/gogrlx/grlx/ingredients/file/http"
-	_ "github.com/gogrlx/grlx/ingredients/file/local"
-	_ "github.com/gogrlx/grlx/ingredients/file/s3"
+	_ "github.com/gogrlx/grlx/ingredients/file"
 	_ "github.com/gogrlx/grlx/ingredients/service/systemd"
 )

--- a/ingredients/file/file.go
+++ b/ingredients/file/file.go
@@ -434,7 +434,7 @@ func (f File) PropertiesForMethod(method string) (map[string]string, error) {
 		return ingredients.MethodPropsSet{
 			ingredients.MethodProps{Key: "name", Type: "string", IsReq: true},
 			ingredients.MethodProps{Key: "source", Type: "string", IsReq: true},
-			ingredients.MethodProps{Key: "hash", Type: "string", IsReq: true},
+			ingredients.MethodProps{Key: "hash", Type: "string", IsReq: false},
 			ingredients.MethodProps{Key: "skip_verify", Type: "bool", IsReq: false},
 		}.ToMap(), nil
 	case "contains":

--- a/ingredients/file/file.go
+++ b/ingredients/file/file.go
@@ -431,9 +431,12 @@ func (f File) PropertiesForMethod(method string) (map[string]string, error) {
 			"source_hashes": "[]string",
 		}, nil
 	case "cached":
-		return map[string]string{
-			"source": "string", "source_hash": "string",
-		}, nil
+		return ingredients.MethodPropsSet{
+			ingredients.MethodProps{Key: "name", Type: "string", IsReq: true},
+			ingredients.MethodProps{Key: "source", Type: "string", IsReq: true},
+			ingredients.MethodProps{Key: "hash", Type: "string", IsReq: true},
+			ingredients.MethodProps{Key: "skip_verify", Type: "bool", IsReq: false},
+		}.ToMap(), nil
 	case "contains":
 		return map[string]string{
 			"name": "string", "text": "[]string",

--- a/ingredients/file/fileAbsent.go
+++ b/ingredients/file/fileAbsent.go
@@ -12,24 +12,20 @@ import (
 
 func (f File) absent(ctx context.Context, test bool) (types.Result, error) {
 	var notes []fmt.Stringer
-	name, ok := f.params["name"].(string)
-	if !ok {
+	err := f.validate()
+	if err != nil {
 		return types.Result{
 			Succeeded: false, Failed: true, Notes: notes,
-		}, types.ErrMissingName
+		}, err
 	}
+	name := f.params["name"].(string)
 	name = filepath.Clean(name)
-	if name == "" {
-		return types.Result{
-			Succeeded: false, Failed: true, Notes: notes,
-		}, types.ErrMissingName
-	}
 	if name == "/" {
 		return types.Result{
 			Succeeded: false, Failed: true, Notes: notes,
 		}, types.ErrDeleteRoot
 	}
-	_, err := os.Stat(name)
+	_, err = os.Stat(name)
 	if errors.Is(err, os.ErrNotExist) {
 		notes = append(notes, types.Snprintf("%v is already absent", name))
 		return types.Result{

--- a/ingredients/file/fileAbsent_test.go
+++ b/ingredients/file/fileAbsent_test.go
@@ -18,7 +18,7 @@ func compareResults(t *testing.T, result types.Result, expected types.Result) {
 		t.Errorf("expected failed to be %v, got %v", expected.Failed, result.Failed)
 	}
 	if len(result.Notes) != len(expected.Notes) {
-		t.Errorf("expected %v notes, got %v", len(expected.Notes), len(result.Notes))
+		t.Errorf("expected %v notes, got %v.\nGot %v", len(expected.Notes), len(result.Notes), result.Notes)
 	}
 	for i, note := range result.Notes {
 		if note.String() != expected.Notes[i].String() {

--- a/ingredients/file/fileAbsent_test.go
+++ b/ingredients/file/fileAbsent_test.go
@@ -10,23 +10,6 @@ import (
 	"github.com/gogrlx/grlx/types"
 )
 
-func compareResults(t *testing.T, result types.Result, expected types.Result) {
-	if result.Succeeded != expected.Succeeded {
-		t.Errorf("expected succeeded to be %v, got %v", expected.Succeeded, result.Succeeded)
-	}
-	if result.Failed != expected.Failed {
-		t.Errorf("expected failed to be %v, got %v", expected.Failed, result.Failed)
-	}
-	if len(result.Notes) != len(expected.Notes) {
-		t.Errorf("expected %v notes, got %v. Got %v", len(expected.Notes), len(result.Notes), result.Notes)
-	}
-	for i, note := range result.Notes {
-		if note.String() != expected.Notes[i].String() {
-			t.Errorf("expected note %v to be %s, got %s", i, expected.Notes[i].String(), note.String())
-		}
-	}
-}
-
 func TestAbsent(t *testing.T) {
 	tempDir := t.TempDir()
 	existingFile := filepath.Join(tempDir, "there-is-a-file-here")

--- a/ingredients/file/fileAbsent_test.go
+++ b/ingredients/file/fileAbsent_test.go
@@ -1,0 +1,135 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogrlx/grlx/types"
+)
+
+func compareResults(t *testing.T, result types.Result, expected types.Result) {
+	if result.Succeeded != expected.Succeeded {
+		t.Errorf("expected succeeded to be %v, got %v", expected.Succeeded, result.Succeeded)
+	}
+	if result.Failed != expected.Failed {
+		t.Errorf("expected failed to be %v, got %v", expected.Failed, result.Failed)
+	}
+	if len(result.Notes) != len(expected.Notes) {
+		t.Errorf("expected %v notes, got %v", len(expected.Notes), len(result.Notes))
+	}
+	for i, note := range result.Notes {
+		if note.String() != expected.Notes[i].String() {
+			t.Errorf("expected note %v to be %v, got %v", i, expected.Notes[i], note)
+		}
+	}
+}
+
+func TestAbsent(t *testing.T) {
+	tempDir := t.TempDir()
+	existingFile := filepath.Join(tempDir, "there-is-a-file-here")
+	os.Create(existingFile)
+	sampleDir := filepath.Join(tempDir, "there-is-a-dir-here")
+	os.Mkdir(sampleDir, 0o755)
+	file := filepath.Join(sampleDir, "there-is-a-file-here")
+	os.Create(file)
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected types.Result
+		error    error
+		test     bool
+	}{
+		{
+			name: "IncorrectFilename",
+			params: map[string]interface{}{
+				"name": 1,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingName,
+		},
+		{
+			name: "AbsentRoot",
+			params: map[string]interface{}{
+				"name": "/",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrDeleteRoot,
+		},
+		{
+			name: "AbsentNonExistent",
+			params: map[string]interface{}{
+				"name": filepath.Join(tempDir, "there-isnt-a-file-here"),
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   false,
+				Notes:     []fmt.Stringer{types.Snprintf("%s is already absent", filepath.Join(tempDir, "there-isnt-a-file-here"))},
+			},
+			error: nil,
+		},
+		{
+			name: "AbsentTestRun",
+			params: map[string]interface{}{
+				"name": existingFile,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("%s would be deleted", existingFile)},
+			},
+			test: true,
+		},
+		{
+			name: "AbsentTestActual",
+			params: map[string]interface{}{
+				"name": existingFile,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("%s has been deleted", existingFile)},
+			},
+		},
+		{
+			name: "AbesentDeletePopulatedDirs",
+			params: map[string]interface{}{
+				"name": sampleDir,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{},
+			},
+			error: &os.PathError{Op: "remove", Path: sampleDir, Err: fmt.Errorf("directory not empty")},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := File{
+				id:     "",
+				method: "",
+				params: test.params,
+			}
+			result, err := f.absent(context.TODO(), test.test)
+			if test.error != nil && err.Error() != test.error.Error() {
+				t.Errorf("expected error %v, got %v", test.error, err)
+			}
+			compareResults(t, result, test.expected)
+		})
+	}
+}

--- a/ingredients/file/fileAbsent_test.go
+++ b/ingredients/file/fileAbsent_test.go
@@ -18,11 +18,11 @@ func compareResults(t *testing.T, result types.Result, expected types.Result) {
 		t.Errorf("expected failed to be %v, got %v", expected.Failed, result.Failed)
 	}
 	if len(result.Notes) != len(expected.Notes) {
-		t.Errorf("expected %v notes, got %v.\nGot %v", len(expected.Notes), len(result.Notes), result.Notes)
+		t.Errorf("expected %v notes, got %v. Got %v", len(expected.Notes), len(result.Notes), result.Notes)
 	}
 	for i, note := range result.Notes {
 		if note.String() != expected.Notes[i].String() {
-			t.Errorf("expected note %v to be %v, got %v", i, expected.Notes[i], note)
+			t.Errorf("expected note %v to be %s, got %s", i, expected.Notes[i].String(), note.String())
 		}
 	}
 }
@@ -122,7 +122,7 @@ func TestAbsent(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			f := File{
 				id:     "",
-				method: "",
+				method: "absent",
 				params: test.params,
 			}
 			result, err := f.absent(context.TODO(), test.test)

--- a/ingredients/file/fileAppend.go
+++ b/ingredients/file/fileAppend.go
@@ -25,11 +25,6 @@ func (f File) append(ctx context.Context, test bool) (types.Result, error) {
 		}, types.ErrMissingName
 	}
 	name = filepath.Clean(name)
-	if name == "" {
-		return types.Result{
-			Succeeded: false, Failed: true, Notes: notes,
-		}, types.ErrMissingName
-	}
 	if name == "/" {
 		return types.Result{
 			Succeeded: false, Failed: true, Notes: notes,

--- a/ingredients/file/fileAppend.go
+++ b/ingredients/file/fileAppend.go
@@ -65,6 +65,7 @@ func (f File) append(ctx context.Context, test bool) (types.Result, error) {
 	}
 	if errors.Is(err, types.ErrMissingContent) {
 		f, err := os.OpenFile(name, os.O_APPEND|os.O_WRONLY, 0o644)
+		// TODO: Bug consider muxing errors to make this more descriptive of the issue that occurred
 		if err != nil {
 			return types.Result{
 				Succeeded: false, Failed: true, Notes: notes,

--- a/ingredients/file/fileAppend_test.go
+++ b/ingredients/file/fileAppend_test.go
@@ -1,0 +1,96 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogrlx/grlx/types"
+)
+
+func TestAppend(t *testing.T) {
+	tempDir := t.TempDir()
+	existingFile := filepath.Join(tempDir, "there-is-a-file-here")
+	os.Create(existingFile)
+	sampleDir := filepath.Join(tempDir, "there-is-a-dir-here")
+	os.Mkdir(sampleDir, 0o755)
+	file := filepath.Join(sampleDir, "there-is-a-file-here")
+	os.Create(file)
+	fileReadOnly := filepath.Join(tempDir, "there-is-a-read-only-file-here")
+	_, err := os.Create(fileReadOnly)
+	if err != nil {
+		t.Fatalf("failed to create read-only file %s: %v", fileReadOnly, err)
+	}
+	err = os.Chmod(fileReadOnly, 0o555)
+	if err != nil {
+		t.Fatalf("failed to chmod read-only file %s: %v", fileReadOnly, err)
+	}
+
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected types.Result
+		error    error
+		test     bool
+	}{
+		{
+			name: "IncorrectFilename",
+			params: map[string]interface{}{
+				"name": 1,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingName,
+		},
+		{
+			name: "AppendRoot",
+			params: map[string]interface{}{
+				"name": "/",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrModifyRoot,
+		},
+		// TODO: Should this be a failure? We should not be getting an open error as we SHOULD be able to open but not write.
+		{
+			name: "AppendFileInvalidPermissions",
+			params: map[string]interface{}{
+				"name": fileReadOnly,
+				"text": "test",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{types.SimpleNote("")},
+			},
+			error: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := File{
+				id:     "",
+				method: "",
+				params: test.params,
+			}
+			result, err := f.append(context.TODO(), test.test)
+			if err != nil || test.error != nil {
+				if (err == nil && test.error != nil) || (err != nil && test.error == nil) {
+					t.Errorf("expected error %v, got %v", test.error, err)
+				} else if err.Error() != test.error.Error() {
+					t.Errorf("expected error %v, got %v", test.error, err)
+				}
+			}
+			compareResults(t, result, test.expected)
+		})
+	}
+}

--- a/ingredients/file/fileAppend_test.go
+++ b/ingredients/file/fileAppend_test.go
@@ -42,6 +42,8 @@ func TestAppend(t *testing.T) {
 		t.Fatalf("failed to create file without content %s: %v", fileWithoutContent, err)
 	}
 
+	fakePath := filepath.Join("/", "fakepath")
+
 	tests := []struct {
 		name     string
 		params   map[string]interface{}
@@ -108,6 +110,28 @@ func TestAppend(t *testing.T) {
 				Notes:     []fmt.Stringer{types.Snprintf("file %s does not contain all specified content", fileWithoutContent), types.Snprintf("appended %s", fileWithoutContent)},
 			},
 			error: nil,
+		},
+		{
+			name:   "AppendFileWithoutContent",
+			params: map[string]interface{}{"name": fileWithoutContent, "text": "test"},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   false,
+				Notes:     []fmt.Stringer{types.Snprintf("file %s does not contain all specified content", fileWithoutContent), types.Snprintf("appended %s", fileWithoutContent)},
+			},
+			error: nil,
+		},
+		{
+			name:   "AppendDirectory",
+			params: map[string]interface{}{"name": fakePath},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{types.Snprintf("failed to open %s", fakePath)},
+			},
+			error: fmt.Errorf("open %s: permission denied", fakePath),
 		},
 	}
 	for _, test := range tests {

--- a/ingredients/file/fileCached.go
+++ b/ingredients/file/fileCached.go
@@ -41,7 +41,7 @@ func (f File) cached(ctx context.Context, test bool) (types.Result, error) {
 	if skipVerify {
 		_, statErr := os.Stat(cacheDest)
 		if statErr == nil {
-			notes = append(notes, types.Snprintf("%s alreadys exists and skipVerify is true", cacheDest))
+			notes = append(notes, types.Snprintf("%s already exists and skipVerify is true", cacheDest))
 			return types.Result{
 				Succeeded: true, Failed: false,
 				Changed: false, Notes: notes,

--- a/ingredients/file/fileCached_test.go
+++ b/ingredients/file/fileCached_test.go
@@ -157,7 +157,6 @@ func TestCachedSkipVerify(t *testing.T) {
 			"skip_verify": true,
 		},
 	}
-	out, _ := f.dest()
 	if err != nil {
 		t.Fatalf("failed to register local file provider: %v", err)
 	}

--- a/ingredients/file/fileCached_test.go
+++ b/ingredients/file/fileCached_test.go
@@ -1,0 +1,80 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gogrlx/grlx/types"
+)
+
+func TestCached(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected types.Result
+		error    error
+		test     bool
+	}{
+		{
+			name:   "TestCachedMissingSource",
+			params: map[string]interface{}{},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingSource,
+		},
+		{
+			name: "TestCachedMissingHash",
+			params: map[string]interface{}{
+				"source": "test",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingHash,
+		},
+		{
+			name: "TestCachedUnkwnownProtocol",
+			params: map[string]interface{}{
+				"name":        "testName",
+				"source":      "/test",
+				"skip_verify": true,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: errors.Join(ErrUnknownProtocol, errors.New("unknown protocol: file")),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := File{
+				id:     "",
+				method: "",
+				params: test.params,
+			}
+			result, err := f.cached(context.TODO(), test.test)
+			if err != nil || test.error != nil {
+				if (err == nil && test.error != nil) || (err != nil && test.error == nil) {
+					t.Errorf("expected error %v, got %v", test.error, err)
+				} else if err.Error() != test.error.Error() {
+					t.Errorf("expected error %v, got %v", test.error, err)
+				}
+			}
+			compareResults(t, result, test.expected)
+		})
+	}
+}
+
+// return types.Result{
+// 	Succeeded: false, Failed: true, Notes: notes,
+// }, types.ErrMissingSource

--- a/ingredients/file/fileCached_test.go
+++ b/ingredients/file/fileCached_test.go
@@ -2,13 +2,14 @@ package file
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+
+	_ "github.com/gogrlx/grlx/ingredients/file/hashers"
 
 	"github.com/gogrlx/grlx/types"
 )
@@ -51,18 +52,18 @@ func TestCached(t *testing.T) {
 			error: types.ErrMissingHash,
 		},
 		{
-			name: "TestCachedUnkwnownProtocol",
+			name: "TestSuccesfulCached",
 			params: map[string]interface{}{
 				"name":        "testName",
 				"source":      "/test",
 				"skip_verify": true,
 			},
 			expected: types.Result{
-				Succeeded: false,
-				Failed:    true,
-				Notes:     []fmt.Stringer{},
+				Succeeded: true,
+				Failed:    false,
+				Notes:     []fmt.Stringer{types.SimpleNote("skip_testName has been cached")},
 			},
-			error: errors.Join(ErrUnknownProtocol, errors.New("unknown protocol: file")),
+			error: nil,
 		},
 	}
 	for _, test := range tests {

--- a/ingredients/file/fileContains.go
+++ b/ingredients/file/fileContains.go
@@ -98,17 +98,17 @@ func (f File) contains(ctx context.Context, test bool) (types.Result, bytes.Buff
 					Succeeded: false, Failed: true, Notes: notes,
 				}, content, types.ErrMissingHash
 			}
+			f, err := os.Open(sourceDest)
+			if err != nil {
+				notes = append(notes, types.Snprintf("failed to open cached source %s", sourceDest))
+				return types.Result{
+					Succeeded: false, Failed: true,
+					Changed: false, Notes: notes,
+				}, content, err
+			}
+			defer f.Close()
+			io.Copy(&content, f)
 		}
-		f, err := os.Open(sourceDest)
-		if err != nil {
-			notes = append(notes, types.Snprintf("failed to open cached source %s", sourceDest))
-			return types.Result{
-				Succeeded: false, Failed: true,
-				Changed: false, Notes: notes,
-			}, content, err
-		}
-		defer f.Close()
-		io.Copy(&content, f)
 	}
 	{
 		var srces []interface{}
@@ -240,17 +240,17 @@ func (f File) contains(ctx context.Context, test bool) (types.Result, bytes.Buff
 					Succeeded: false, Failed: true,
 				}, content, types.ErrMissingHash
 			}
+			f, err := os.Open(sourceDest)
+			if err != nil {
+				notes = append(notes, types.Snprintf("failed to open cached source %s", sourceDest))
+				return types.Result{
+					Succeeded: false, Failed: true,
+					Changed: false, Notes: notes,
+				}, content, err
+			}
+			defer f.Close()
+			io.Copy(&content, f)
 		}
-		f, err := os.Open(sourceDest)
-		if err != nil {
-			notes = append(notes, types.Snprintf("failed to open cached source %s", sourceDest))
-			return types.Result{
-				Succeeded: false, Failed: true,
-				Changed: false, Notes: notes,
-			}, content, err
-		}
-		defer f.Close()
-		io.Copy(&content, f)
 	}
 	file, err := os.Open(name)
 	if err != nil {

--- a/ingredients/file/fileContains_test.go
+++ b/ingredients/file/fileContains_test.go
@@ -7,13 +7,28 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gogrlx/grlx/config"
 	"github.com/gogrlx/grlx/types"
 )
 
 func TestContains(t *testing.T) {
 	tempDir := t.TempDir()
 	existingFile := filepath.Join(tempDir, "there-is-a-file-here")
-	os.Create(existingFile)
+	f, _ := os.Create(existingFile)
+	defer f.Close()
+	if _, err := f.WriteString("hello world"); err != nil {
+		t.Fatal(err)
+	}
+	existingFileSrc := filepath.Join(tempDir, "there-is-a-src-here")
+	f, _ = os.Create(existingFileSrc)
+	defer f.Close()
+	if _, err := f.WriteString("hello world"); err != nil {
+		t.Fatal(err)
+	}
+
+	config.CacheDir = tempDir
+	defer func() { config.CacheDir = "" }()
+
 	tests := []struct {
 		name     string
 		params   map[string]interface{}
@@ -45,18 +60,6 @@ func TestContains(t *testing.T) {
 			},
 			error: types.ErrModifyRoot,
 		},
-		// {
-		// 	name: "ContainsTest",
-		// 	params: map[string]interface{}{
-		// 		"name": existingFile,
-		// 	},
-		// 	expected: types.Result{
-		// 		Succeeded: false,
-		// 		Failed:    true,
-		// 		Notes:     []fmt.Stringer{types.Snprintf("failed to open cached source")},
-		// 	},
-		// 	error: nil,
-		// },
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/ingredients/file/fileContains_test.go
+++ b/ingredients/file/fileContains_test.go
@@ -1,0 +1,75 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogrlx/grlx/types"
+)
+
+func TestContains(t *testing.T) {
+	tempDir := t.TempDir()
+	existingFile := filepath.Join(tempDir, "there-is-a-file-here")
+	os.Create(existingFile)
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected types.Result
+		error    error
+		test     bool
+	}{
+		{
+			name: "IncorrectFilename",
+			params: map[string]interface{}{
+				"name": 1,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingName,
+		},
+		{
+			name: "ContainsRoot",
+			params: map[string]interface{}{
+				"name": "/",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrModifyRoot,
+		},
+		// {
+		// 	name: "ContainsTest",
+		// 	params: map[string]interface{}{
+		// 		"name": existingFile,
+		// 	},
+		// 	expected: types.Result{
+		// 		Succeeded: false,
+		// 		Failed:    true,
+		// 		Notes:     []fmt.Stringer{types.Snprintf("failed to open cached source")},
+		// 	},
+		// 	error: nil,
+		// },
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := File{
+				id:     "",
+				method: "",
+				params: test.params,
+			}
+			result, _, err := f.contains(context.TODO(), test.test)
+			if test.error != nil && err.Error() != test.error.Error() {
+				t.Errorf("expected error %v, got %v", test.error, err)
+			}
+			compareResults(t, result, test.expected)
+		})
+	}
+}

--- a/ingredients/file/fileDirectory.go
+++ b/ingredients/file/fileDirectory.go
@@ -52,18 +52,20 @@ func (f File) directory(ctx context.Context, test bool) (types.Result, error) {
 		// create the dir if "makeDirs" is true or not defined
 		if val, ok := f.params["makedirs"].(bool); ok && val || !ok {
 			d.makeDirs = true
-			errCreate := os.MkdirAll(name, 0o755)
-			notes = append(notes, types.Snprintf("creating directory %s", name))
-			if errCreate != nil {
-				return types.Result{
-					Succeeded: false, Failed: true, Notes: notes,
-				}, errCreate
+			if test {
+				notes = append(notes, types.Snprintf("would create directory %s", name))
+			} else {
+				// TODO: Bug, this should check if the directory exists to correctly return that a directory altready exists and it is being skipped for creation
+				errCreate := os.MkdirAll(name, 0o755)
+				notes = append(notes, types.Snprintf("creating directory %s", name))
+				if errCreate != nil {
+					return types.Result{
+						Succeeded: false, Failed: true, Notes: notes,
+					}, errCreate
+				}
+
 			}
 
-		}
-		// TODO: Bug, this should be moved to potentially NOT create the directory
-		if test {
-			notes = append(notes, types.Snprintf("would create directory %s", name))
 		}
 	}
 	// chown the directory to the named user

--- a/ingredients/file/fileDirectory.go
+++ b/ingredients/file/fileDirectory.go
@@ -44,7 +44,7 @@ func (f File) directory(ctx context.Context, test bool) (types.Result, error) {
 	if name == "/" {
 		return types.Result{
 			Succeeded: false, Failed: true, Notes: notes,
-		}, fmt.Errorf("refusing to delete root")
+		}, types.ErrDeleteRoot
 	}
 	d := dir{}
 	// create the directory if it doesn't exist

--- a/ingredients/file/fileDirectory.go
+++ b/ingredients/file/fileDirectory.go
@@ -61,6 +61,7 @@ func (f File) directory(ctx context.Context, test bool) (types.Result, error) {
 			}
 
 		}
+		// TODO: Bug, this should be moved to potentially NOT create the directory
 		if test {
 			notes = append(notes, types.Snprintf("would create directory %s", name))
 		}
@@ -156,6 +157,7 @@ func (f File) directory(ctx context.Context, test bool) (types.Result, error) {
 	}
 	// chmod the directory to the named dirmode if it is defined
 	{
+		// TODO: Bug, this should at least be able to return a successful result
 		if val, ok := f.params["dir_mode"].(string); ok {
 			d.dirMode = val
 			modeVal, _ := strconv.ParseUint(d.dirMode, 8, 32)
@@ -237,5 +239,8 @@ func (f File) directory(ctx context.Context, test bool) (types.Result, error) {
 		}
 	}
 
-	return f.undef()
+	// TODO: Bug, any directory operations will report as a failure and can never succeed
+	out, err := f.undef()
+	out.Notes = append(notes, out.Notes...)
+	return out, err
 }

--- a/ingredients/file/fileDirectory_test.go
+++ b/ingredients/file/fileDirectory_test.go
@@ -16,6 +16,7 @@ func TestDirectory(t *testing.T) {
 	os.Mkdir(sampleDir, 0o755)
 	file := filepath.Join(sampleDir, "there-is-a-file-here")
 	os.Create(file)
+	fileModeDNE := filepath.Join(sampleDir, "file-mode-does-not-exist")
 	tests := []struct {
 		name     string
 		params   map[string]interface{}
@@ -73,16 +74,16 @@ func TestDirectory(t *testing.T) {
 			error: nil,
 		},
 		{
-			name: "DirectoryTestChangeMode",
+			name: "DirectoryTestChangeDirMode",
 			params: map[string]interface{}{
 				"name":     sampleDir,
 				"dir_mode": "755",
-				"makeDirs": true,
+				"makedirs": true,
 			},
 			expected: types.Result{
 				Succeeded: true,
 				Failed:    false,
-				Notes:     []fmt.Stringer{types.Snprintf("would create directory %s", sampleDir), types.Snprintf("would chmod %s to 755", sampleDir), types.SimpleNote("")},
+				Notes:     []fmt.Stringer{types.Snprintf("would create directory %s", sampleDir), types.Snprintf("would chmod %s to 755", sampleDir)},
 			},
 			test:  true,
 			error: nil,
@@ -90,16 +91,46 @@ func TestDirectory(t *testing.T) {
 		{
 			name: "DirectoryChangeModeNotExist",
 			params: map[string]interface{}{
-				"name":     sampleDir,
+				"name":     fileModeDNE,
 				"dir_mode": "755",
 				"makedirs": false,
 			},
 			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: fmt.Errorf("chmod %s: no such file or directory", fileModeDNE),
+		},
+		{
+			name: "DirectoryTestChageFileMode",
+			params: map[string]interface{}{
+				"name":      sampleDir,
+				"file_mode": "755",
+				"makedirs":  true,
+			},
+			expected: types.Result{
 				Succeeded: true,
 				Failed:    false,
-				Notes:     []fmt.Stringer{types.Snprintf("would create directory %s", sampleDir), types.Snprintf("would chmod %s to 755", sampleDir), types.SimpleNote("")},
+				Notes:     []fmt.Stringer{types.Snprintf("would create directory %s", sampleDir), types.Snprintf("would chmod %s to 755", sampleDir)},
 			},
+			test:  true,
 			error: nil,
+		},
+		{
+			// TODO: Update to match error for a directory that doesn't exist
+			name: "DirectoryChangeFileModeNotExist",
+			params: map[string]interface{}{
+				"name":      fileModeDNE,
+				"file_mode": "755",
+				"makedirs":  false,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: fmt.Errorf("chmod %s: no such file or directory", fileModeDNE),
 		},
 	}
 	for _, test := range tests {

--- a/ingredients/file/fileDirectory_test.go
+++ b/ingredients/file/fileDirectory_test.go
@@ -1,0 +1,77 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogrlx/grlx/types"
+)
+
+func TestDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	sampleDir := filepath.Join(tempDir, "there-is-a-dir-here")
+	os.Mkdir(sampleDir, 0o755)
+	file := filepath.Join(sampleDir, "there-is-a-file-here")
+	os.Create(file)
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected types.Result
+		error    error
+		test     bool
+	}{
+		{
+			name: "IncorrectFilename",
+			params: map[string]interface{}{
+				"name": 1,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingName,
+		},
+		{
+			name: "DirectoryRoot",
+			params: map[string]interface{}{
+				"name": "/",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrDeleteRoot,
+		},
+		{
+			name: "DirectoryExistingNoAction",
+			params: map[string]interface{}{
+				"name": sampleDir,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     nil,
+			},
+			error: fmt.Errorf("method  undefined"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := File{
+				id:     "",
+				method: "",
+				params: test.params,
+			}
+			result, err := f.directory(context.Background(), test.test)
+			if err.Error() != test.error.Error() {
+				t.Errorf("expected error to be %v, got %v", test.error, err)
+			}
+			compareResults(t, result, test.expected)
+		})
+	}
+}

--- a/ingredients/file/file_register.go
+++ b/ingredients/file/file_register.go
@@ -1,0 +1,15 @@
+package file
+
+import (
+	"github.com/gogrlx/grlx/ingredients/file/http"
+	"github.com/gogrlx/grlx/ingredients/file/local"
+	"github.com/gogrlx/grlx/ingredients/file/s3"
+	"github.com/gogrlx/grlx/types"
+)
+
+func init() {
+	provMap = make(map[string]types.FileProvider)
+	RegisterProvider(http.HTTPFile{})
+	RegisterProvider(s3.S3File{})
+	RegisterProvider(local.LocalFile{})
+}

--- a/ingredients/file/file_test.go
+++ b/ingredients/file/file_test.go
@@ -30,3 +30,63 @@ func TestRecipeStepUsage(t *testing.T) {
 		os.Remove("testFile")
 	})
 }
+
+func TestDest(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]interface{}
+		out    string
+		error  error
+	}{
+		{
+			name: "TestMissingName",
+			params: map[string]interface{}{
+				"name": "",
+			},
+			out:   "",
+			error: types.ErrMissingName,
+		},
+		{
+			name: "TestSkipVerify",
+			params: map[string]interface{}{
+				"name":        "testFile",
+				"skip_verify": true,
+			},
+			out:   "skip_testFile",
+			error: nil,
+		},
+		{
+			name: "TestMissingHash",
+			params: map[string]interface{}{
+				"name": "testFile",
+			},
+			out:   "",
+			error: types.ErrMissingHash,
+		},
+		{
+			name: "TestMissingHash",
+			params: map[string]interface{}{
+				"name": "testFile",
+				"hash": "testHash",
+			},
+			out:   "testHash",
+			error: nil,
+		},
+	}
+	for _, test := range tests {
+		file := File{
+			id:     "",
+			method: "",
+			params: test.params,
+		}
+		t.Run(test.name, func(t *testing.T) {
+			out, err := file.dest()
+			if err != test.error {
+				t.Errorf("expected error %v, got %v", test.error, err)
+			}
+			if out != test.out {
+				t.Errorf("expected %s, got %s", test.out, out)
+			}
+		})
+	}
+}

--- a/ingredients/file/file_test_utils.go
+++ b/ingredients/file/file_test_utils.go
@@ -15,6 +15,7 @@ func compareResults(t *testing.T, result types.Result, expected types.Result) {
 	}
 	if len(result.Notes) != len(expected.Notes) {
 		t.Errorf("expected %v notes, got %v. Got %v", len(expected.Notes), len(result.Notes), result.Notes)
+		return
 	}
 	for i, note := range result.Notes {
 		if note.String() != expected.Notes[i].String() {

--- a/ingredients/file/file_test_utils.go
+++ b/ingredients/file/file_test_utils.go
@@ -1,0 +1,24 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/gogrlx/grlx/types"
+)
+
+func compareResults(t *testing.T, result types.Result, expected types.Result) {
+	if result.Succeeded != expected.Succeeded {
+		t.Errorf("expected succeeded to be %v, got %v", expected.Succeeded, result.Succeeded)
+	}
+	if result.Failed != expected.Failed {
+		t.Errorf("expected failed to be %v, got %v", expected.Failed, result.Failed)
+	}
+	if len(result.Notes) != len(expected.Notes) {
+		t.Errorf("expected %v notes, got %v. Got %v", len(expected.Notes), len(result.Notes), result.Notes)
+	}
+	for i, note := range result.Notes {
+		if note.String() != expected.Notes[i].String() {
+			t.Errorf("expected note `%v` to be `%s`, got `%s`", i, expected.Notes[i].String(), note.String())
+		}
+	}
+}

--- a/ingredients/file/http/provider.go
+++ b/ingredients/file/http/provider.go
@@ -8,7 +8,7 @@ import (
 	httpc "net/http"
 	"os"
 
-	"github.com/gogrlx/grlx/ingredients/file"
+	// "github.com/gogrlx/grlx/ingredients/file"
 	"github.com/gogrlx/grlx/ingredients/file/hashers"
 	"github.com/gogrlx/grlx/types"
 )
@@ -110,6 +110,6 @@ func (lf HTTPFile) Verify(ctx context.Context) (bool, error) {
 	return cf.Verify(ctx)
 }
 
-func init() {
-	file.RegisterProvider(HTTPFile{})
-}
+// func init() {
+// 	file.RegisterProvider(HTTPFile{})
+// }

--- a/ingredients/file/local/provider.go
+++ b/ingredients/file/local/provider.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/gogrlx/grlx/ingredients/file"
 	"github.com/gogrlx/grlx/ingredients/file/hashers"
 	"github.com/gogrlx/grlx/types"
 )
@@ -83,5 +82,4 @@ func (lf LocalFile) Verify(ctx context.Context) (bool, error) {
 }
 
 func init() {
-	file.RegisterProvider(LocalFile{})
 }

--- a/ingredients/file/providers.go
+++ b/ingredients/file/providers.go
@@ -20,10 +20,6 @@ var (
 	ErrDuplicateProtocol = errors.New("duplicate protocol")
 )
 
-func init() {
-	provMap = make(map[string]types.FileProvider)
-}
-
 func RegisterProvider(provider types.FileProvider) error {
 	provTex.Lock()
 	defer provTex.Unlock()

--- a/ingredients/file/s3/provider.go
+++ b/ingredients/file/s3/provider.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"context"
 
-	"github.com/gogrlx/grlx/ingredients/file"
 	"github.com/gogrlx/grlx/types"
 )
 
@@ -36,8 +35,4 @@ func (sf S3File) Protocols() []string {
 
 func (sf S3File) Verify(context.Context) (bool, error) {
 	return false, nil
-}
-
-func init() {
-	file.RegisterProvider(S3File{})
 }


### PR DESCRIPTION
Attached is the list of initial testing work for `grlx`. Most cases are passing with a few exceptions around hashers and fileDirectory.

- test(ingredients): added test for fileAbsent.go
- refactor: change to types.ErrDeleteRoot instead of custom
- test(files): updates to testing output
- chore(gitignore): updated ignore to not commit coverage.out
- feat(file): updated absent to use MethodPropsSet
- test(file): initial testing of fileAppend
- test(file): added destination testing for caching
- test(file): WIP added cache server testing
- test(file): initial work on fileContains testing
- test(file): initial testing of fileAppend
- test(file): initial testing of fileDirectory
- refactor(file): move file provider initialization up a level
- test(file): moved test validation to its own file
- test(file): fixed Cached test to reflect correct behavior after registration
- fix(file): fixes issues with error reporting happening incorrectly
- test(file): new fileAppend tests added
- test(file): remove invalid check
- fix(file): fix spelling issues
- test(file): updated cache tests for better coverage
- test(file): added more append tests
- test(file): removed extra dest call in test for cached test
- fix(file): updated directory to more correctly report notes
- test(file): added directory tests for dir_mode
- fix(file): moved test to correctly handle not creating a directory
- fix(test): fixed file utils to fail more gracefully
- test(file): updated dir tests to handle more error cases and tests
- test(file): updated caching configuration
