### PR TITLE
docs(readme): add docs.grlx.dev to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ grlx -T \* cmd run whoami
 grlx -T \* cmd run --out json -- uname -a
 ```
 
+## Documentation
+Please see the [official docs site](https://docs.grlx.dev) for complete documentation.
+
 ## Why grlx?
 
 Our team started out using competing solutions, and we ran into scalability issues.


### PR DESCRIPTION
Adds the official documentation link to the README for visibility.
