### PR TITLE
ci: added new Debian-based Docker image

### DIFF
--- a/docker/sprout-debian.dockerfile
+++ b/docker/sprout-debian.dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+# Note: this dockerfile must be used from a subfolder
+FROM golang:1.21 AS builder
+VOLUME /go/src
+WORKDIR /app
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+ADD . /app
+RUN make sprout
+
+
+FROM debian:bookworm-slim
+COPY --from=builder /app/bin/sprout sprout
+ENTRYPOINT ["/sprout"]


### PR DESCRIPTION
Adds a debian:bookworm-slim image to the config.

Closes #90 .