### PR TITLE
test: adding more files testing

### DIFF
--- a/ingredients/file/fileContent.go
+++ b/ingredients/file/fileContent.go
@@ -138,6 +138,7 @@ func (f File) content(ctx context.Context, test bool) (types.Result, error) {
 		var srces []interface{}
 		var srcHashes []interface{}
 		var ok bool
+		fmt.Printf("sources: %v\n", f.params["sources"])
 		if srces, ok = f.params["sources"].([]interface{}); ok && len(srces) > 0 {
 			if srcHashes, ok = f.params["source_hashes"].([]interface{}); ok {
 				foundSource = true

--- a/ingredients/file/fileContent.go
+++ b/ingredients/file/fileContent.go
@@ -29,6 +29,13 @@ func (f File) content(ctx context.Context, test bool) (types.Result, error) {
 	foundSource := false
 	_, _, _, _ = template, sources, sourceHashes, foundSource
 	var ok bool
+	err := f.validate()
+	if err != nil {
+		return types.Result{
+			Succeeded: false, Failed: true,
+			Changed: false, Notes: notes,
+		}, err
+	}
 	{
 		name, ok = f.params["name"].(string)
 		if !ok {

--- a/ingredients/file/fileContent_test.go
+++ b/ingredients/file/fileContent_test.go
@@ -1,0 +1,166 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogrlx/grlx/config"
+	"github.com/gogrlx/grlx/types"
+)
+
+func TestFileContent(t *testing.T) {
+	tempDir := t.TempDir()
+	cd := config.CacheDir
+	// Restore config.CacheDir after test
+	defer func() { config.CacheDir = cd }()
+	config.CacheDir = filepath.Join(tempDir, "cache")
+	newDir := filepath.Join(tempDir, "this/item")
+	dirEntry := filepath.Dir(newDir)
+	fmt.Println(newDir)
+	doesExist := filepath.Join(tempDir, "doesExist")
+	_, err := os.Create(doesExist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceExist := filepath.Join(tempDir, "sourceExist")
+	_, err = os.Create(sourceExist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected types.Result
+		error    error
+		test     bool
+	}{
+		{
+			name: "incorrect name",
+			params: map[string]interface{}{
+				"name": 1,
+				"text": "string",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingName,
+		},
+		{
+			name: "root",
+			params: map[string]interface{}{
+				"name": "/",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrModifyRoot,
+		},
+		{
+			name: "makedirs",
+			params: map[string]interface{}{
+				"name":     newDir,
+				"makedirs": true,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   true,
+				Notes: []fmt.Stringer{
+					types.Snprintf("created directory %s", dirEntry),
+				},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "skip_verify file exists",
+			params: map[string]interface{}{
+				"name":        doesExist,
+				"skip_verify": true,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "source missing hash",
+			params: map[string]interface{}{
+				"name":   doesExist,
+				"source": "nope",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingHash,
+			test:  false,
+		},
+		{
+			name: "sources missing hashes",
+			params: map[string]interface{}{
+				"name":          doesExist,
+				"sources":       []string{"nope", "nope2"},
+				"source_hashes": []string{"thing1"},
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes: []fmt.Stringer{
+					types.Snprintf("failed to open cached source %s", newDir),
+				},
+			},
+			error: types.ErrMissingHash,
+			test:  false,
+		},
+		{
+			name: "source with hash",
+			params: map[string]interface{}{
+				"name":        doesExist,
+				"source":      sourceExist,
+				"source_hash": "test1",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{},
+			},
+			error: errors.Join(fmt.Errorf("open %s: no such file or directory", filepath.Join(config.CacheDir, "test1")), types.ErrCacheFailure),
+			test:  false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := File{
+				id:     "",
+				method: "content",
+				params: test.params,
+			}
+			result, err := f.content(context.TODO(), test.test)
+			if err != nil {
+				if test.error == nil {
+					t.Errorf("expected error to be nil but got %v", err)
+				} else if err.Error() != test.error.Error() {
+					t.Errorf("expected error %v, got %v", test.error, err)
+				}
+			}
+			compareResults(t, result, test.expected)
+		})
+	}
+}

--- a/ingredients/file/fileContent_test.go
+++ b/ingredients/file/fileContent_test.go
@@ -113,8 +113,8 @@ func TestFileContent(t *testing.T) {
 		{
 			name: "sources missing hashes",
 			params: map[string]interface{}{
-				"name":          doesExist,
-				"sources":       []string{"nope", "nope2"},
+				"name":          "test",
+				"sources":       []string{sourceExist, doesExist},
 				"source_hashes": []string{"thing1"},
 			},
 			expected: types.Result{
@@ -122,7 +122,7 @@ func TestFileContent(t *testing.T) {
 				Failed:    true,
 				Changed:   false,
 				Notes: []fmt.Stringer{
-					types.Snprintf("failed to open cached source %s", newDir),
+					types.Snprintf("sources and source_hashes must be the same length"),
 				},
 			},
 			error: types.ErrMissingHash,
@@ -141,6 +141,7 @@ func TestFileContent(t *testing.T) {
 				Changed:   false,
 				Notes:     []fmt.Stringer{},
 			},
+			// TODO: This should be a lot cleaner, relying on a stdblib error that we have little control over is difficult to test.
 			error: errors.Join(fmt.Errorf("open %s: no such file or directory", filepath.Join(config.CacheDir, "test1")), types.ErrCacheFailure),
 			test:  false,
 		},

--- a/ingredients/file/fileContent_test.go
+++ b/ingredients/file/fileContent_test.go
@@ -128,6 +128,23 @@ func TestFileContent(t *testing.T) {
 			error: types.ErrMissingHash,
 			test:  false,
 		},
+		// Expect this to match the single source case
+		{
+			name: "sources missing hashes w/ skip_verify",
+			params: map[string]interface{}{
+				"name":        "test",
+				"sources":     []string{sourceExist, doesExist},
+				"skip_verify": true,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{},
+			},
+			error: nil,
+			test:  false,
+		},
 		{
 			name: "source with hash",
 			params: map[string]interface{}{

--- a/ingredients/file/fileManaged_test.go
+++ b/ingredients/file/fileManaged_test.go
@@ -1,0 +1,130 @@
+package file
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogrlx/grlx/types"
+)
+
+func TestManaged(t *testing.T) {
+	// TODO: Determine how to set up the farmer local file system path
+	tempDir := t.TempDir()
+	existingFile := filepath.Join(tempDir, "managed-file")
+	f, err := os.Create(existingFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	f.WriteString("This is the existing file content")
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		t.Fatal(err)
+	}
+	existingFileHash := h.Sum(nil)
+	hashString := fmt.Sprintf("md5:%x", existingFileHash)
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected types.Result
+		error    error
+		test     bool
+	}{
+		{
+			name: "incorrect name",
+			params: map[string]interface{}{
+				"name": 1,
+				"text": "string",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingName,
+		},
+		{
+			name: "root",
+			params: map[string]interface{}{
+				"name": "/",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrModifyRoot,
+		},
+		{
+			name: "Simple case",
+			params: map[string]interface{}{
+				"name":        existingFile,
+				"source":      "grlx://test/managed-file",
+				"skip_verify": true,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				// TODO: Notes not implemented yet for file.managed
+				Notes: []fmt.Stringer{},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "Simple case with backup",
+			params: map[string]interface{}{
+				"name":        existingFile,
+				"source":      "grlx://test/managed-file",
+				"skip_verify": true,
+				"backup":      true,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				// TODO: Notes not implemented yet for file.managed
+				Notes: []fmt.Stringer{},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "Simple case with source_hash",
+			params: map[string]interface{}{
+				"name":        existingFile,
+				"source":      "grlx://test/managed-file",
+				"source_hash": hashString,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				// TODO: Notes not implemented yet for file.managed
+				Notes: []fmt.Stringer{},
+			},
+			error: nil,
+			test:  false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := File{
+				id:     "",
+				method: "managed",
+				params: test.params,
+			}
+			result, err := f.managed(context.TODO(), test.test)
+			if test.error != nil && err.Error() != test.error.Error() {
+				t.Errorf("expected error %v, got %v", test.error, err)
+			}
+			compareResults(t, result, test.expected)
+		})
+	}
+}

--- a/ingredients/file/fileManaged_test.go
+++ b/ingredients/file/fileManaged_test.go
@@ -112,6 +112,42 @@ func TestManaged(t *testing.T) {
 			error: nil,
 			test:  false,
 		},
+		{
+			// TODO: Verify that this is the expected behavior
+			name: "Simple case no create",
+			params: map[string]interface{}{
+				"name":        existingFile,
+				"source":      "grlx://test/managed-file",
+				"source_hash": hashString,
+				"create":      false,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				// TODO: Notes not implemented yet for file.managed
+				Notes: []fmt.Stringer{},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "External case",
+			params: map[string]interface{}{
+				"name":        existingFile,
+				"source":      "https://releases.grlx.dev/linux/amd64/v1.0.0/grlx",
+				"source_hash": "md5:0f9847d3b437488309329463b1454f40",
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				// TODO: Notes not implemented yet for file.managed
+				Notes: []fmt.Stringer{},
+			},
+			error: nil,
+			test:  false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/ingredients/file/fileSymlink.go
+++ b/ingredients/file/fileSymlink.go
@@ -66,7 +66,7 @@ func (f File) symlink(ctx context.Context, test bool) (types.Result, error) {
 			}, nil
 		}
 		// check if it's not already a symlink
-		if nameStat.Mode()&os.ModeSymlink == 0 {
+		if nameStat == nil || nameStat.Mode()&os.ModeSymlink == 0 {
 			// create the symlink
 			err = os.Symlink(target, name)
 			if err != nil {

--- a/ingredients/file/fileSymlink_test.go
+++ b/ingredients/file/fileSymlink_test.go
@@ -1,0 +1,119 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gogrlx/grlx/types"
+)
+
+func TestSymlink(t *testing.T) {
+	tempDir := t.TempDir()
+	tempFile := tempDir + "/test"
+	tempTarget := tempDir + "/target"
+	existingSymlink := tempDir + "/existingSymlink"
+	os.Symlink(tempTarget, existingSymlink)
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected types.Result
+		error    error
+		test     bool
+	}{
+		{
+			name: "IncorrectFilename",
+			params: map[string]interface{}{
+				"name": 1,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingName,
+		},
+		{
+			name: "SymlinkRoot",
+			params: map[string]interface{}{
+				"name": "/",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrModifyRoot,
+		},
+		{
+			name: "SymlinkMissingTarget",
+			params: map[string]interface{}{
+				"name": "/tmp/test",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrMissingTarget,
+		},
+		{
+			name: "SymlinkCreateTest",
+			params: map[string]interface{}{
+				"name":   tempFile,
+				"target": tempTarget,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   false,
+				Notes:     []fmt.Stringer{types.Snprintf("would create symlink %s pointing to %s", tempFile, tempTarget)},
+			},
+			error: nil,
+			test:  true,
+		},
+		{
+			name: "SymlinkCreate",
+			params: map[string]interface{}{
+				"name":   tempFile,
+				"target": tempTarget,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("created symlink %s pointing to %s", tempFile, tempTarget)},
+			},
+			error: nil,
+		},
+		{
+			name: "SymlinkExistingCreate",
+			params: map[string]interface{}{
+				"name":   existingSymlink,
+				"target": tempTarget,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{},
+			},
+			error: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := File{
+				id:     "",
+				method: "symlink",
+				params: test.params,
+			}
+			result, err := f.symlink(context.TODO(), test.test)
+			if test.error != nil && err.Error() != test.error.Error() {
+				t.Errorf("expected error %v, got %v", test.error, err)
+			}
+			compareResults(t, result, test.expected)
+		})
+	}
+}

--- a/ingredients/file/fileTouch.go
+++ b/ingredients/file/fileTouch.go
@@ -85,7 +85,7 @@ func (f File) touch(ctx context.Context, test bool) (types.Result, error) {
 			return types.Result{
 				Succeeded: false, Failed: true,
 				Changed: false, Notes: []fmt.Stringer{
-					types.SimpleNote(fmt.Sprintf("filepath `%s` is missing and `makedirs` is false", fileDir)),
+					types.Snprintf("filepath `%s` is missing and `makedirs` is false", fileDir),
 				},
 			}, types.ErrPathNotFound
 		}
@@ -94,7 +94,7 @@ func (f File) touch(ctx context.Context, test bool) (types.Result, error) {
 				return types.Result{
 					Succeeded: true, Failed: false,
 					Changed: true, Notes: []fmt.Stringer{
-						types.SimpleNote(fmt.Sprintf("file `%s` to be created with provided timestamps", name)),
+						types.Snprintf("file `%s` to be created with provided timestamps", name),
 					},
 				}, nil
 			}
@@ -103,7 +103,7 @@ func (f File) touch(ctx context.Context, test bool) (types.Result, error) {
 				return types.Result{
 					Succeeded: false, Failed: true,
 					Changed: false, Notes: []fmt.Stringer{
-						types.SimpleNote(fmt.Sprintf("failed to create parent directory %s", fileDir)),
+						types.Snprintf("failed to create parent directory `%s`", fileDir),
 					},
 				}, dirErr
 			}
@@ -113,7 +113,7 @@ func (f File) touch(ctx context.Context, test bool) (types.Result, error) {
 			return types.Result{
 				Succeeded: false, Failed: true,
 				Changed: false, Notes: []fmt.Stringer{
-					types.SimpleNote(fmt.Sprintf("failed to create file %s", name)),
+					types.Snprintf("failed to create file `%s`", name),
 				},
 			}, errCreate
 		}
@@ -132,17 +132,17 @@ func (f File) touch(ctx context.Context, test bool) (types.Result, error) {
 			return types.Result{
 				Succeeded: true, Failed: false,
 				Changed: false, Notes: []fmt.Stringer{
-					types.SimpleNote(fmt.Sprintf("file `%s` already has provided timestamps", name)),
+					types.Snprintf("file `%s` already has provided timestamps", name),
 				},
 			}, nil
 		} else if !omt.Equal(mTime) {
-			notes = append(notes, types.SimpleNote(fmt.Sprintf("mtime of `%s` will be changed", name)))
+			notes = append(notes, types.Snprintf("mtime of `%s` will be changed", name))
 			return types.Result{
 				Succeeded: true, Failed: false,
 				Changed: true, Notes: notes,
 			}, nil
 		} else if !oat.Equal(aTime) {
-			notes = append(notes, types.SimpleNote(fmt.Sprintf("atime of `%s` will be changed", name)))
+			notes = append(notes, types.Snprintf("atime of `%s` will be changed", name))
 			return types.Result{
 				Succeeded: true, Failed: false,
 				Changed: true, Notes: notes,
@@ -155,11 +155,11 @@ func (f File) touch(ctx context.Context, test bool) (types.Result, error) {
 		return types.Result{
 			Succeeded: false, Failed: true,
 			Changed: false, Notes: []fmt.Stringer{
-				types.SimpleNote(fmt.Sprintf("failed to change timestamps of `%s`", name)),
+				types.Snprintf("failed to change timestamps of `%s`", name),
 			},
 		}, err
 	}
-	notes = append(notes, types.SimpleNote(fmt.Sprintf("timestamps of `%s` changed", name)))
+	notes = append(notes, types.Snprintf("timestamps of `%s` changed", name))
 	return types.Result{
 		Succeeded: true, Failed: false,
 		Changed: true, Notes: notes,

--- a/ingredients/file/fileTouch_test.go
+++ b/ingredients/file/fileTouch_test.go
@@ -1,0 +1,213 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogrlx/grlx/types"
+)
+
+func TestTouch(t *testing.T) {
+	tempDir := t.TempDir()
+	existingFile := filepath.Join(tempDir, "there-is-a-file-here")
+	missingBase := filepath.Join(tempDir, "there-isnt-a-dir-here")
+	missingDir := filepath.Join(missingBase, "item")
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		expected types.Result
+		error    error
+		test     bool
+	}{
+		{
+			name:   "IncorrrectFilename",
+			params: map[string]interface{}{},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "TouchRoot",
+			params: map[string]interface{}{
+				"name": "/",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Notes:     []fmt.Stringer{},
+			},
+			error: types.ErrModifyRoot,
+		},
+		{
+			name: "TouchFile",
+			params: map[string]interface{}{
+				"name": existingFile,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("timestamps of `%s` changed", existingFile)},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "TouchFileAtime",
+			params: map[string]interface{}{
+				"name":  existingFile,
+				"atime": "2021-01-01T00:00:00Z",
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("timestamps of `%s` changed", existingFile)},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "TouchFileAtimeFail",
+			params: map[string]interface{}{
+				"name":  existingFile,
+				"atime": "-1",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{types.Snprintf("failed to parse atime")},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "TouchFileMtime",
+			params: map[string]interface{}{
+				"name":  existingFile,
+				"mtime": "2021-01-01T00:00:00Z",
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("timestamps of `%s` changed", existingFile)},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "TouchFileMtimeFail",
+			params: map[string]interface{}{
+				"name":  existingFile,
+				"mtime": "-1",
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   false,
+				Notes:     []fmt.Stringer{types.Snprintf("failed to parse mtime")},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "TouchFileMakeDirs",
+			params: map[string]interface{}{
+				"name":     existingFile,
+				"makedirs": true,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("timestamps of `%s` changed", existingFile)},
+			},
+			error: nil,
+			test:  false,
+		},
+		{
+			name: "TouchFileMakeDirsMissingDir",
+			params: map[string]interface{}{
+				"name": missingDir,
+			},
+			expected: types.Result{
+				Succeeded: false,
+				Failed:    true,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("filepath `%s` is missing and `makedirs` is false", missingBase)},
+			},
+			error: types.ErrPathNotFound,
+			test:  false,
+		},
+		{
+			name: "TouchFileMakeDirsDir",
+			params: map[string]interface{}{
+				"name":     missingDir,
+				"makedirs": true,
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("file `%s` to be created with provided timestamps", missingDir)},
+			},
+			error: nil,
+			test:  true,
+		},
+		// TODO: this is currently failing on the notes comparison
+		{
+			name: "TouchFileTestMTime",
+			params: map[string]interface{}{
+				"name":  existingFile,
+				"mtime": "2021-01-01T00:00:00Z",
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("mtime of `%s` will be changed", missingDir)},
+			},
+			error: nil,
+			test:  true,
+		},
+		// TODO: this is currently failing on the notes comparison
+		{
+			name: "TouchFileTestATime",
+			params: map[string]interface{}{
+				"name":  existingFile,
+				"atime": "2021-01-01T00:00:00Z",
+			},
+			expected: types.Result{
+				Succeeded: true,
+				Failed:    false,
+				Changed:   true,
+				Notes:     []fmt.Stringer{types.Snprintf("atime of `%s` will be changed", missingDir)},
+			},
+			error: nil,
+			test:  true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := File{
+				id:     "",
+				method: "absent",
+				params: test.params,
+			}
+			result, err := f.touch(context.TODO(), test.test)
+			if test.error != nil && err.Error() != test.error.Error() {
+				t.Errorf("expected error %v, got %v", test.error, err)
+			}
+			compareResults(t, result, test.expected)
+		})
+	}
+}


### PR DESCRIPTION
Adds more tests for file activities. Currently includes:

- test(file): added fileSymlink tests
- fix(file): fixed bug in fileSymlink
- style(file): updated fileTouch to use types.Snprintf
- test(file): added the initial fileTouch tests
- fix(file): fixed incorrect variables, short-circuited test ops
- test(file): added longer and more in depth fileTouch tests
