### PR TITLE
fix(config): use XDG_CONFIG_HOME for grlx cert path when set

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -117,8 +117,11 @@ func LoadConfig(binary string) {
 			if err != nil {
 				log.Fatal(err)
 			}
-			// TODO: use XDG_CONFIG_HOME if set
-			certPath := filepath.Join(dirname, ".config/grlx/tls-rootca.pem")
+			configDir := os.Getenv("XDG_CONFIG_HOME")
+			if configDir == "" {
+				configDir = filepath.Join(dirname, ".config")
+			}
+			certPath := filepath.Join(configDir, "grlx/tls-rootca.pem")
 			jety.Set("grlxrootca", certPath)
 		case "farmer":
 			jety.SetDefault("certificatevalidtime", 365*24*time.Hour)


### PR DESCRIPTION
## Summary

Respects the XDG Base Directory Specification by checking for the `XDG_CONFIG_HOME` environment variable before falling back to `$HOME/.config`.

When `XDG_CONFIG_HOME` is set, grlx will now look for its certificate at `$XDG_CONFIG_HOME/grlx/tls-rootca.pem` instead of hardcoding `~/.config/grlx/tls-rootca.pem`.

## Changes

- Check `XDG_CONFIG_HOME` environment variable in the `grlx` binary config loading
- Fall back to `$HOME/.config` if `XDG_CONFIG_HOME` is not set (preserves existing behavior)

## Testing

- Build verified: `go build ./...`

Fixes #122