### PR TITLE
feat(config): make API server timeouts configurable

### DIFF
--- a/cmd/farmer/main.go
+++ b/cmd/farmer/main.go
@@ -94,11 +94,10 @@ func StartAPIServer() {
 		Tag:       Tag,
 	}, CertFile)
 	srv := &http.Server{
-		// TODO add all below settings to configuration
 		Addr:         FarmerInterface + ":" + FarmerAPIPort,
-		WriteTimeout: time.Second * 120,
-		ReadTimeout:  time.Second * 120,
-		IdleTimeout:  time.Second * 120,
+		WriteTimeout: config.APIWriteTimeout,
+		ReadTimeout:  config.APIReadTimeout,
+		IdleTimeout:  config.APIIdleTimeout,
 		Handler:      r,
 	}
 	apiServer = srv

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,9 @@ var configLoaded sync.Once
 
 var (
 	AdminPubkeys         []string
+	APIIdleTimeout       time.Duration
+	APIReadTimeout       time.Duration
+	APIWriteTimeout      time.Duration
 	CacheDir             string
 	CertFile             string
 	CertHosts            []string
@@ -124,6 +127,9 @@ func LoadConfig(binary string) {
 			certPath := filepath.Join(configDir, "grlx/tls-rootca.pem")
 			jety.Set("grlxrootca", certPath)
 		case "farmer":
+			jety.SetDefault("apiwritetimeout", 120*time.Second)
+			jety.SetDefault("apireadtimeout", 120*time.Second)
+			jety.SetDefault("apiidletimeout", 120*time.Second)
 			jety.SetDefault("certificatevalidtime", 365*24*time.Hour)
 			jety.SetDefault("certfile", "/etc/grlx/pki/farmer/tls-cert.pem")
 			jety.SetDefault("farmerpki", "/etc/grlx/pki/farmer/")
@@ -220,6 +226,9 @@ func LoadConfig(binary string) {
 	default:
 		LogLevel = log.LNotice
 	}
+	APIIdleTimeout = jety.GetDuration("apiidletimeout")
+	APIReadTimeout = jety.GetDuration("apireadtimeout")
+	APIWriteTimeout = jety.GetDuration("apiwritetimeout")
 	CacheDir = jety.GetString("cachedir")
 	CertFile = jety.GetString("certfile")
 	CertHosts = jety.GetStringSlice("certhosts")


### PR DESCRIPTION
Adds `apiwritetimeout`, `apireadtimeout`, and `apiidletimeout` configuration options for the farmer HTTP server. All three default to 120 seconds (matching the previous hardcoded values).

Users can now tune these in their farmer config file:

```yaml
apiwritetimeout: 60s
apireadtimeout: 60s
apiidletimeout: 300s
```

## Changes
- Added three new `time.Duration` config variables in `config/config.go`
- Set defaults (120s) in the farmer config block
- Read values via `jety.GetDuration` alongside existing config reads
- Updated `cmd/farmer/main.go` to use config values instead of hardcoded timeouts

## Testing
- `go build ./...` passes
- Existing tests unaffected (pre-existing failures are unrelated)

Fixes #118