### PR TITLE
test(serve): cover UI fallback and cache behavior

### DIFF
--- a/internal/serve/ui.go
+++ b/internal/serve/ui.go
@@ -44,8 +44,9 @@ func UIHandler() http.Handler {
 			return
 		}
 
-		// SPA fallback: serve index.html for client-side routing
-		r.URL.Path = "/"
-		fileServer.ServeHTTP(w, r)
+		// SPA fallback: serve index.html for client-side routing.
+		fallbackRequest := r.Clone(r.Context())
+		fallbackRequest.URL.Path = "/"
+		fileServer.ServeHTTP(w, fallbackRequest)
 	})
 }

--- a/internal/serve/ui_test.go
+++ b/internal/serve/ui_test.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -31,7 +32,8 @@ func TestUIHandler_SPAFallback(t *testing.T) {
 	handler := UIHandler()
 
 	// Request a path that doesn't exist as a file — should get index.html
-	req := httptest.NewRequest(http.MethodGet, "/sprouts/abc123", nil)
+	const fallbackPath = "/sprouts/abc123"
+	req := httptest.NewRequest(http.MethodGet, fallbackPath, nil)
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -43,13 +45,31 @@ func TestUIHandler_SPAFallback(t *testing.T) {
 	if !strings.Contains(body, "grlx") {
 		t.Fatal("expected SPA fallback to serve index.html content")
 	}
+	if req.URL.Path != fallbackPath {
+		t.Fatalf("expected fallback to preserve request path %q, got %q", fallbackPath, req.URL.Path)
+	}
 }
 
 func TestUIHandler_AssetsCacheHeaders(t *testing.T) {
 	handler := UIHandler()
 
-	// The placeholder dist has an assets/ directory but no files in it.
-	// Just verify a non-asset path doesn't get the immutable cache header.
+	assetPath := findEmbeddedAsset(t)
+	req := httptest.NewRequest(http.MethodGet, "/"+assetPath, nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected asset status 200, got %d", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=31536000, immutable" {
+		t.Fatalf("expected immutable cache header, got %q", cc)
+	}
+}
+
+func TestUIHandler_IndexDoesNotUseImmutableCache(t *testing.T) {
+	handler := UIHandler()
+
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 
@@ -58,4 +78,31 @@ func TestUIHandler_AssetsCacheHeaders(t *testing.T) {
 	if cc := rec.Header().Get("Cache-Control"); strings.Contains(cc, "immutable") {
 		t.Fatal("root path should not have immutable cache header")
 	}
+}
+
+func findEmbeddedAsset(t *testing.T) string {
+	t.Helper()
+
+	distFS, err := fs.Sub(uiAssets, "dist")
+	if err != nil {
+		t.Fatalf("open embedded dist filesystem: %v", err)
+	}
+
+	var assetPath string
+	err = fs.WalkDir(distFS, "assets", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() && assetPath == "" {
+			assetPath = path
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded assets: %v", err)
+	}
+	if assetPath == "" {
+		t.Fatal("expected at least one embedded asset")
+	}
+	return assetPath
 }


### PR DESCRIPTION
## Summary
- preserve the original request URL path when serving the SPA fallback
- add UI handler coverage for fallback request preservation
- assert embedded asset requests receive immutable cache headers while index.html does not

## Tests
- go test -race ./internal/serve
- staticcheck ./internal/serve
- go test -race ./...
- staticcheck ./...

## Notes
- go generate ./... still fails before and after this change because internal/serve/ui.go expects ../../../grlx-web-ui to exist as a sibling checkout in this clone layout.