### PR TITLE
fix(nats): use atomic counter for connection attempts

### DIFF
--- a/cmd/farmer/main.go
+++ b/cmd/farmer/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -316,7 +317,8 @@ func RunNATSServer() {
 
 func ConnectFarmer(ctx context.Context, done chan<- struct{}) {
 	defer close(done)
-	connectionAttempts := 1
+	var connectionAttempts atomic.Int64
+	connectionAttempts.Store(1)
 	maxFarmerReconnect := 30
 	RootCA := config.RootCA
 	BusURL := config.FarmerBusURL
@@ -354,8 +356,7 @@ func ConnectFarmer(ctx context.Context, done chan<- struct{}) {
 		nats.MaxReconnects(maxFarmerReconnect),
 		nats.ReconnectWait(time.Second*15),
 		nats.DisconnectHandler(func(_ *nats.Conn) {
-			connectionAttempts++
-			log.Warnf("WARN: Reconnecting Farmer to NATS bus, attempt: %d\n", connectionAttempts)
+			log.Warnf("WARN: Reconnecting Farmer to NATS bus, attempt: %d\n", connectionAttempts.Add(1))
 		}),
 	)
 	if err != nil {
@@ -365,10 +366,10 @@ func ConnectFarmer(ctx context.Context, done chan<- struct{}) {
 		log.Fatalf("Failed to connect Farmer to NATS bus: %v", err)
 	}
 	for !nc.IsConnected() {
-		connectionAttempts++
-		log.Debugf("Attempting to pair Farmer to NATS bus (attempt %d/%d).", connectionAttempts, maxFarmerReconnect)
-		if connectionAttempts >= maxFarmerReconnect {
-			log.Fatalf("Failed to connect Farmer to NATS %d times, exiting.", connectionAttempts)
+		attempts := connectionAttempts.Add(1)
+		log.Debugf("Attempting to pair Farmer to NATS bus (attempt %d/%d).", attempts, maxFarmerReconnect)
+		if attempts >= int64(maxFarmerReconnect) {
+			log.Fatalf("Failed to connect Farmer to NATS %d times, exiting.", attempts)
 		}
 		select {
 		case <-ctx.Done():
@@ -377,7 +378,7 @@ func ConnectFarmer(ctx context.Context, done chan<- struct{}) {
 		case <-time.After(time.Second * 15):
 		}
 	}
-	connectionAttempts = 0
+	connectionAttempts.Store(0)
 	log.Debugf("Successfully joined Farmer to NATS bus")
 
 	if err := log.ConnectNATS(BusURL); err != nil {

--- a/cmd/sprout/main.go
+++ b/cmd/sprout/main.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -91,7 +92,7 @@ func createConfigRoot() {
 
 func ConnectSprout(ctx context.Context, done chan<- struct{}) {
 	defer close(done)
-	connectionAttempts := 0
+	var connectionAttempts atomic.Int64
 	var err error
 	SproutRootCA := config.SproutRootCA
 	FarmerInterface := config.FarmerInterface
@@ -118,8 +119,7 @@ func ConnectSprout(ctx context.Context, done chan<- struct{}) {
 		nats.MaxReconnects(-1),
 		nats.ReconnectWait(time.Second*15),
 		nats.DisconnectHandler(func(_ *nats.Conn) {
-			connectionAttempts++
-			log.Debugf("Reconnecting to Farmer, attempt: %d\n", connectionAttempts)
+			log.Debugf("Reconnecting to Farmer, attempt: %d\n", connectionAttempts.Add(1))
 		}),
 	)
 	for err != nil {
@@ -132,8 +132,7 @@ func ConnectSprout(ctx context.Context, done chan<- struct{}) {
 			nats.MaxReconnects(-1),
 			nats.ReconnectWait(time.Second*15),
 			nats.DisconnectHandler(func(_ *nats.Conn) {
-				connectionAttempts++
-				log.Debugf("Reconnecting to Farmer, attempt: %d\n", connectionAttempts)
+				log.Debugf("Reconnecting to Farmer, attempt: %d\n", connectionAttempts.Add(1))
 			}),
 		)
 	}


### PR DESCRIPTION
## Summary

Follow-up to the P0–P2 hardening PRs. `connectionAttempts` was incremented from the NATS `DisconnectHandler` callback (a separate goroutine) while the farmer's connect loop also read and wrote it — a genuine data race flagged under `-race`. Convert it to an `atomic.Int64` in both the farmer and sprout connect routines.

Counting semantics are preserved: `Add(1)` returns the post-increment value, matching the old `++`-then-read pattern (farmer starts at 1, sprout at 0; reset via `Store(0)`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/...`
- [ ] CI green (ideally with `-race`)