### PR TITLE
fix(cli): clean errors for NATS no-responders and timeout

### DIFF
--- a/cmd/grlx/cmd/cmd.go
+++ b/cmd/grlx/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	gcmd "github.com/gogrlx/grlx/v2/cmd/grlx/ingredients/cmd"
 	apitypes "github.com/gogrlx/grlx/v2/internal/api/types"
 	"github.com/gogrlx/grlx/v2/internal/pki"
+	nats "github.com/nats-io/nats.go"
 	"github.com/spf13/cobra"
 )
 
@@ -63,13 +65,15 @@ var cmdCmdRun = &cobra.Command{
 		}
 		results, err := gcmd.FRun(effectiveTarget, command)
 		if err != nil {
-			switch err {
-			case pki.ErrSproutIDNotFound:
-				log.Fatalf("A targeted Sprout does not exist or is not accepted..")
+			switch {
+			case errors.Is(err, pki.ErrSproutIDNotFound):
+				log.Fatalf("A targeted Sprout does not exist or is not accepted.")
+			case errors.Is(err, nats.ErrNoResponders):
+				log.Fatalf("No Sprout responded: the target may be offline or not subscribed.")
+			case errors.Is(err, nats.ErrTimeout):
+				log.Fatalf("Timed out waiting for the Sprout to respond after %d seconds.", timeout)
 			default:
-				// TODO: handle endpoint timeouts here
-				// TODO: Error running command on the Sprout: nats: no responders available for request  run.go:65
-				log.Panic(err)
+				log.Fatalf("Error running command on the Sprout: %v", err)
 			}
 		}
 		switch outputMode {


### PR DESCRIPTION
## Summary

Replaces the `log.Panic` fallback in `grlx cmd run` — which dumped a Go stack trace on the common `nats: no responders available for request` error — with `errors.Is` checks that print actionable messages:

- `pki.ErrSproutIDNotFound` → sprout does not exist / not accepted
- `nats.ErrNoResponders` → target offline or not subscribed
- `nats.ErrTimeout` → timed out after N seconds
- anything else → plain formatted error (no panic)

Resolves the two `TODO`s at `cmd/grlx/cmd/cmd.go:70-71`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/grlx/...`
- [ ] Manual: run `grlx cmd run` against an offline sprout, confirm clean message