### PR TITLE
feat(sprout): expire local job logs via configurable TTL

### DIFF
--- a/cmd/sprout/main.go
+++ b/cmd/sprout/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gogrlx/grlx/v2/internal/ingredients"
 	"github.com/gogrlx/grlx/v2/internal/ingredients/cmd"
 	"github.com/gogrlx/grlx/v2/internal/ingredients/test"
+	"github.com/gogrlx/grlx/v2/internal/jobs"
 	"github.com/gogrlx/grlx/v2/internal/pki"
 
 	nats "github.com/nats-io/nats.go"
@@ -96,6 +97,10 @@ func ConnectSprout(ctx context.Context, done chan<- struct{}) {
 	SproutRootCA := config.SproutRootCA
 	FarmerInterface := config.FarmerInterface
 	FarmerBusURL := config.FarmerBusURL
+	// Capture job-log settings before the local tls.Config below shadows the
+	// config package identifier.
+	jobLogDir := config.JobLogDir
+	jobLogTTL := config.JobLogTTL
 	opt, err := nats.NkeyOptionFromSeed(config.NKeySproutPrivFile)
 	if err != nil {
 		log.Panicf("failed to load NKey seed: %v", err)
@@ -150,6 +155,8 @@ func ConnectSprout(ctx context.Context, done chan<- struct{}) {
 	if err != nil {
 		log.Panicf("Error with natsInit: %v", err)
 	}
+	// Expire old local job logs written by cook runs on this sprout.
+	jobs.StartSproutReaper(ctx, jobLogDir, jobLogTTL)
 	<-ctx.Done()
 	nc.Close()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -244,12 +244,14 @@ func LoadConfig(binary string) {
 			jety.SetDefault("sproutrootca", filepath.Join(systemConfigRoot, "pki/sprout/tls-rootca.pem"))
 			jety.SetDefault("nkeysproutpubfile", filepath.Join(systemConfigRoot, "pki/sprout/sprout.nkey.pub"))
 			jety.SetDefault("joblogdir", "/var/cache/grlx/sprout/jobs")
+			jety.SetDefault("joblogttl", 30*24*time.Hour) // 30 days default
 			jety.SetDefault("nkeysproutprivfile", filepath.Join(systemConfigRoot, "pki/sprout/sprout.nkey"))
 			jety.SetDefault("cachedir", "/var/cache/grlx/sprout/files/provided")
 			jety.SetDefault("rootca_retry_delay", 5*time.Second)
 			jety.SetDefault("nkey_retry_delay", 5*time.Second)
 
 			JobLogDir = jety.GetString("joblogdir")
+			JobLogTTL = jety.GetDuration("joblogttl")
 		}
 		jety.WriteConfig()
 	})

--- a/internal/jobs/listener.go
+++ b/internal/jobs/listener.go
@@ -11,7 +11,8 @@ package jobs
 // the cli user's machine. For now, they are only stored farmer-side.
 // Jobs can be retrieved from the farmer with the grlx job command.
 
-// TODO configure expiration time for job data on the sprout and farmer
+// Job data expiration is configurable via the joblogttl setting on both the
+// farmer (Store.StartReaperCtx) and the sprout (StartSproutReaper).
 
 import (
 	"encoding/json"

--- a/internal/jobs/sproutreaper.go
+++ b/internal/jobs/sproutreaper.go
@@ -1,0 +1,75 @@
+package jobs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	log "github.com/gogrlx/grlx/v2/internal/log"
+)
+
+// StartSproutReaper launches a background goroutine that periodically removes
+// job log files older than ttl from a flat job log directory (the sprout-side
+// layout, where files live directly under logDir as <jid>.jsonl rather than in
+// per-sprout subdirectories). It checks once per hour and stops when ctx is
+// cancelled. A ttl of 0 or negative disables expiration entirely.
+func StartSproutReaper(ctx context.Context, logDir string, ttl time.Duration) {
+	if ttl <= 0 {
+		log.Notice("sprout job log expiration disabled (ttl <= 0)")
+		return
+	}
+	if logDir == "" {
+		return
+	}
+	log.Noticef("sprout job log reaper started: ttl=%s", ttl)
+	go func() {
+		reapFlatDir(logDir, ttl)
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				log.Notice("sprout job log reaper stopped")
+				return
+			case <-ticker.C:
+				reapFlatDir(logDir, ttl)
+			}
+		}
+	}()
+}
+
+// reapFlatDir deletes *.jsonl files (and companion *.meta.json files) directly
+// under logDir whose modification time is older than ttl.
+func reapFlatDir(logDir string, ttl time.Duration) {
+	cutoff := time.Now().Add(-ttl)
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Errorf("sprout reaper: reading %s: %v", logDir, err)
+		}
+		return
+	}
+	removed := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			jobFile := filepath.Join(logDir, entry.Name())
+			if rmErr := os.Remove(jobFile); rmErr != nil {
+				log.Errorf("sprout reaper: removing %s: %v", jobFile, rmErr)
+				continue
+			}
+			removed++
+		}
+	}
+	if removed > 0 {
+		log.Noticef("sprout reaper: removed %d expired job log(s)", removed)
+	}
+}

--- a/internal/jobs/sproutreaper_test.go
+++ b/internal/jobs/sproutreaper_test.go
@@ -1,0 +1,127 @@
+package jobs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReapFlatDirRemovesExpiredJobs(t *testing.T) {
+	dir := t.TempDir()
+
+	oldFile := filepath.Join(dir, "old-job.jsonl")
+	newFile := filepath.Join(dir, "new-job.jsonl")
+
+	if err := os.WriteFile(oldFile, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newFile, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Backdate the old file so it falls outside the TTL window.
+	past := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(oldFile, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	reapFlatDir(dir, 24*time.Hour)
+
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Errorf("expected old-job.jsonl to be removed, but it still exists")
+	}
+	if _, err := os.Stat(newFile); err != nil {
+		t.Errorf("expected new-job.jsonl to still exist, got error: %v", err)
+	}
+}
+
+func TestReapFlatDirIgnoresSubdirsAndNonJSONL(t *testing.T) {
+	dir := t.TempDir()
+
+	// A subdirectory (farmer-style layout) must not be touched or descended.
+	subDir := filepath.Join(dir, "sprout-a")
+	if err := os.MkdirAll(subDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(subDir, "job.jsonl")
+	if err := os.WriteFile(nested, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A non-.jsonl file must be left alone even if old.
+	other := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(other, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	past := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(nested, past, past); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(other, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	reapFlatDir(dir, 24*time.Hour)
+
+	if _, err := os.Stat(nested); err != nil {
+		t.Errorf("expected nested subdir job to be untouched, got: %v", err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Errorf("expected non-jsonl file to be untouched, got: %v", err)
+	}
+}
+
+func TestStartSproutReaperZeroTTLNoOp(t *testing.T) {
+	dir := t.TempDir()
+	jobFile := filepath.Join(dir, "job.jsonl")
+	if err := os.WriteFile(jobFile, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-9999 * time.Hour)
+	if err := os.Chtimes(jobFile, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	// ttl <= 0 disables the reaper entirely; the file must survive.
+	StartSproutReaper(context.Background(), dir, 0)
+
+	if _, err := os.Stat(jobFile); err != nil {
+		t.Errorf("expected job file to still exist when TTL=0, got: %v", err)
+	}
+}
+
+func TestStartSproutReaperReapsOnStartupAndStopsOnCancel(t *testing.T) {
+	dir := t.TempDir()
+	// A pre-expired file lets us confirm the immediate startup reap ran.
+	jobFile := filepath.Join(dir, "stale.jsonl")
+	if err := os.WriteFile(jobFile, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(jobFile, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	StartSproutReaper(ctx, dir, time.Hour)
+
+	// The reaper runs one reap immediately on startup; poll until the stale
+	// file is gone, which proves the goroutine is alive and doing work.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(jobFile); os.IsNotExist(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("reaper did not remove the stale file on startup")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Cancelling must let the goroutine exit without panicking.
+	cancel()
+}


### PR DESCRIPTION
## Summary

The sprout persisted cook step results to its job log dir (`joblogdir`, default `/var/cache/grlx/sprout/jobs`) but never expired them, so job data grew unbounded. This adds sprout-side expiration:

- New `joblogttl` config default on the sprout (30 days, matching the farmer).
- `jobs.StartSproutReaper` / `reapFlatDir`: a context-bound reaper for the sprout's **flat** `<jid>.jsonl` layout (the farmer's `Store` reaper only handles the per-sprout subdir layout).
- Wired into `ConnectSprout`, stops on shutdown via the existing signal context.

Resolves the sprout half of the `listener.go` job-data expiration TODO; the farmer half was already wired via `Store.StartReaperCtx`.

## Notes
- `reapFlatDir` is non-recursive and only touches top-level `*.jsonl`, so it never descends into or disturbs the farmer's per-sprout directories.
- The `config` package identifier is shadowed by a local `*tls.Config` in `ConnectSprout`, so the job-log settings are captured before that declaration.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./internal/jobs/` (new tests: expiry, subdir/non-jsonl safety, ttl<=0 no-op, startup-reap + cancel)
- [ ] CI green