### PR TITLE
feat(cook): run an individual state and its dependencies

### DIFF
--- a/cmd/grlx/cmd/cook.go
+++ b/cmd/grlx/cmd/cook.go
@@ -24,6 +24,7 @@ var (
 	async       bool
 	cookTimeout int
 	testMode    bool
+	targetState string
 )
 
 var cmdCook = &cobra.Command{
@@ -39,6 +40,7 @@ var cmdCook = &cobra.Command{
 		cmdCook.Async = async
 		cmdCook.Env = environment
 		cmdCook.Test = testMode
+		cmdCook.State = targetState
 
 		effectiveTarget, err := resolveEffectiveTarget()
 		if err != nil {
@@ -226,5 +228,6 @@ func init() {
 	addTargetFlags(cmdCook)
 	cmdCook.Flags().IntVar(&cookTimeout, "cook-timeout", 30, "Cancel cook execution and return after X seconds")
 	cmdCook.Flags().BoolVar(&testMode, "test", false, "Run in test mode (dry run without applying changes)")
+	cmdCook.Flags().StringVarP(&targetState, "state", "s", "", "Run only the named state and its requisite dependencies")
 	rootCmd.AddCommand(cmdCook)
 }

--- a/internal/api/types/types.go
+++ b/internal/api/types/types.go
@@ -14,6 +14,7 @@ type (
 		Async   bool            `json:"async"`
 		Env     string          `json:"env"`
 		Recipe  cook.RecipeName `json:"recipe"`
+		State   string          `json:"state,omitempty"`
 		Test    bool            `json:"test"`
 		Timeout time.Duration   `json:"timeout"`
 

--- a/internal/cook/errors.go
+++ b/internal/cook/errors.go
@@ -9,4 +9,6 @@ var (
 	ErrInvalidFormat         = errors.New("invalid recipe format")
 	ErrDuplicateKey          = errors.New("duplicate key in joined maps")
 	ErrRecipePathIsDirectory = errors.New("recipe path resolved to a directory instead of a .grlx file")
+	ErrTargetStepNotFound    = errors.New("target step not found in recipe")
+	ErrDanglingRequisite     = errors.New("step requires an unknown step")
 )

--- a/internal/cook/farmercook.go
+++ b/internal/cook/farmercook.go
@@ -25,13 +25,23 @@ import (
 type CookOption func(*cookOptions)
 
 type cookOptions struct {
-	invokedBy string
+	invokedBy  string
+	targetStep StepID
 }
 
 // WithInvoker sets the pubkey of the user who initiated the cook.
 func WithInvoker(pubkey string) CookOption {
 	return func(o *cookOptions) {
 		o.invokedBy = pubkey
+	}
+}
+
+// WithTargetStep restricts the cook to a single step (and the transitive
+// closure of its requisite dependencies) instead of the whole recipe tree.
+// An empty id runs the full recipe.
+func WithTargetStep(id StepID) CookOption {
+	return func(o *cookOptions) {
+		o.targetStep = id
 	}
 }
 
@@ -147,6 +157,15 @@ func SendCookEvent(sproutID string, recipeID RecipeName, JID string, test bool, 
 	for _, opt := range opts {
 		opt(&co)
 	}
+	// If a target step was requested, prune the tree to that step plus the
+	// transitive closure of its requisite dependencies.
+	if co.targetStep != "" {
+		pruned, pruneErr := PruneToTarget(validSteps, co.targetStep)
+		if pruneErr != nil {
+			return pruneErr
+		}
+		validSteps = pruned
+	}
 	rEnvelope := RecipeEnvelope{
 		JobID:     JID,
 		Steps:     validSteps,
@@ -223,6 +242,3 @@ func ResolveRecipeFilePath(basepath string, recipeID RecipeName) (string, error)
 		return "", err
 	}
 }
-
-// TODO ensure ability to only run individual state (+ dependencies),
-// i.e. start from a root of a given dependency tree

--- a/internal/cook/helpers.go
+++ b/internal/cook/helpers.go
@@ -341,5 +341,51 @@ func validateRecipeTree(recipes []*Step) ([]*Step, error) {
 	return recipes, err
 }
 
-// TODO ensure ability to only run individual state (+ dependencies),
-// i.e. start from a root of a given dependency tree
+// PruneToTarget returns the subset of steps needed to run the single step
+// identified by target: the target itself plus the transitive closure of its
+// requisite dependencies (every step reachable through Requisites). This lets
+// a caller run an individual state (and only what it depends on) instead of
+// the whole recipe tree, starting from the root of a given dependency subtree.
+//
+// The returned steps preserve their original relative order. An error is
+// returned if target is not present in steps, or if a requisite references a
+// step ID that does not exist in steps.
+func PruneToTarget(steps []Step, target StepID) ([]Step, error) {
+	byID := make(map[StepID]Step, len(steps))
+	for _, s := range steps {
+		byID[s.ID] = s
+	}
+	if _, ok := byID[target]; !ok {
+		return nil, fmt.Errorf("%w: %q", ErrTargetStepNotFound, target)
+	}
+
+	keep := make(map[StepID]bool)
+	var visit func(id StepID) error
+	visit = func(id StepID) error {
+		if keep[id] {
+			return nil
+		}
+		step, ok := byID[id]
+		if !ok {
+			return fmt.Errorf("%w: %q", ErrDanglingRequisite, id)
+		}
+		keep[id] = true
+		for _, reqID := range step.Requisites.AllIDs() {
+			if err := visit(reqID); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := visit(target); err != nil {
+		return nil, err
+	}
+
+	pruned := make([]Step, 0, len(keep))
+	for _, s := range steps {
+		if keep[s.ID] {
+			pruned = append(pruned, s)
+		}
+	}
+	return pruned, nil
+}

--- a/internal/cook/prune_test.go
+++ b/internal/cook/prune_test.go
@@ -1,0 +1,128 @@
+package cook
+
+import (
+	"errors"
+	"testing"
+)
+
+func step(id StepID, requires ...StepID) Step {
+	s := Step{ID: id}
+	if len(requires) > 0 {
+		s.Requisites = RequisiteSet{{Condition: Require, StepIDs: requires}}
+	}
+	return s
+}
+
+func ids(steps []Step) []StepID {
+	out := make([]StepID, len(steps))
+	for i, s := range steps {
+		out[i] = s.ID
+	}
+	return out
+}
+
+func contains(steps []Step, id StepID) bool {
+	for _, s := range steps {
+		if s.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPruneToTargetTransitiveClosure(t *testing.T) {
+	// c -> b -> a ; d is unrelated.
+	steps := []Step{
+		step("a"),
+		step("b", "a"),
+		step("c", "b"),
+		step("d"),
+	}
+	pruned, err := PruneToTarget(steps, "c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []StepID{"a", "b", "c"} {
+		if !contains(pruned, want) {
+			t.Errorf("expected pruned set to contain %q, got %v", want, ids(pruned))
+		}
+	}
+	if contains(pruned, "d") {
+		t.Errorf("expected unrelated step d to be excluded, got %v", ids(pruned))
+	}
+}
+
+func TestPruneToTargetPreservesOrder(t *testing.T) {
+	steps := []Step{
+		step("a"),
+		step("b", "a"),
+		step("c", "b"),
+	}
+	pruned, err := PruneToTarget(steps, "c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := ids(pruned)
+	want := []StepID{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order not preserved: expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestPruneToTargetLeafStep(t *testing.T) {
+	steps := []Step{
+		step("a"),
+		step("b", "a"),
+	}
+	pruned, err := PruneToTarget(steps, "a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pruned) != 1 || pruned[0].ID != "a" {
+		t.Errorf("expected only [a], got %v", ids(pruned))
+	}
+}
+
+func TestPruneToTargetMultipleRequisites(t *testing.T) {
+	// c requires both a and b.
+	steps := []Step{
+		step("a"),
+		step("b"),
+		{ID: "c", Requisites: RequisiteSet{{Condition: Require, StepIDs: []StepID{"a", "b"}}}},
+		step("d"),
+	}
+	pruned, err := PruneToTarget(steps, "c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []StepID{"a", "b", "c"} {
+		if !contains(pruned, want) {
+			t.Errorf("expected %q in pruned set, got %v", want, ids(pruned))
+		}
+	}
+	if contains(pruned, "d") {
+		t.Errorf("expected d excluded, got %v", ids(pruned))
+	}
+}
+
+func TestPruneToTargetUnknownTarget(t *testing.T) {
+	steps := []Step{step("a")}
+	_, err := PruneToTarget(steps, "missing")
+	if !errors.Is(err, ErrTargetStepNotFound) {
+		t.Errorf("expected ErrTargetStepNotFound for unknown target, got %v", err)
+	}
+}
+
+func TestPruneToTargetDanglingRequisite(t *testing.T) {
+	// b requires a step that isn't present.
+	steps := []Step{step("b", "ghost")}
+	_, err := PruneToTarget(steps, "b")
+	if !errors.Is(err, ErrDanglingRequisite) {
+		t.Errorf("expected ErrDanglingRequisite for dangling requisite, got %v", err)
+	}
+}

--- a/internal/natsapi/cook.go
+++ b/internal/natsapi/cook.go
@@ -88,7 +88,11 @@ func handleCook(params json.RawMessage) (any, error) {
 		for _, target := range ta.Target {
 			go func(t pki.KeyManager) {
 				defer wg.Done()
-				err := cook.SendCookEvent(t.SproutID, command.Recipe, jid, command.Test, cook.WithInvoker(invokerPubkey))
+				cookOpts := []cook.CookOption{cook.WithInvoker(invokerPubkey)}
+				if command.State != "" {
+					cookOpts = append(cookOpts, cook.WithTargetStep(cook.StepID(command.State)))
+				}
+				err := cook.SendCookEvent(t.SproutID, command.Recipe, jid, command.Test, cookOpts...)
 				if err != nil {
 					mu.Lock()
 					errs[t.SproutID] = err

--- a/internal/serve/openapi.yaml
+++ b/internal/serve/openapi.yaml
@@ -1935,6 +1935,12 @@ components:
           type: string
           description: Recipe name in dot-notation
           example: base.webserver
+        state:
+          type: string
+          description: >-
+            Optional. Run only the named state (step ID) and the transitive
+            closure of its requisite dependencies, instead of the whole recipe.
+          example: install-nginx
         test:
           type: boolean
           description: Run in test (dry-run) mode


### PR DESCRIPTION
## Summary

Adds a `--state`/`-s` flag to `grlx cook` that restricts a run to a single step plus the transitive closure of its requisite dependencies, instead of executing the whole recipe tree. Resolves the "run individual state (+ dependencies)" TODOs in `cook/helpers.go` and `cook/farmercook.go`.

Implementation:
- `cook.PruneToTarget(steps, target)` — pure transitive-requisite-closure over `Requisites.AllIDs()` (covers `require`/`onchanges`/`onfail` + `_any` variants, so the pruned envelope is dependency-complete with no dangling refs). Cycle-safe via a visited/keep map.
- `cook.WithTargetStep` option, applied in `SendCookEvent` (no-op when empty → full recipe).
- `CmdCook.State` API field, plumbed through the `natsapi` cook handler.
- Dedicated `ErrTargetStepNotFound` / `ErrDanglingRequisite` (instead of the misleading `ErrNoRecipe`) — from review feedback.
- OpenAPI `state` field added to `CmdCook`.

## Review
Two adversarial rounds; both confirmed the closure logic is correct (cycle-safe, order-preserving, no dangling requisites, empty-state preserves full-recipe behavior). Applied their actionable fix (dedicated error sentinels).

## Known follow-up (out of scope)
Reviewers noted that a bad `--state` value (like any `SendCookEvent` error) is only logged farmer-side because the cook trigger returns the JID *before* cooking runs, so the CLI waits until `--cook-timeout`. This silent-async-error behavior is pre-existing and affects all cook errors, not just `--state`; surfacing cook errors to the client via the completion stream deserves its own change.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/cook/` (new prune_test: closure, order, leaf, multi-requisite, unknown-target, dangling-requisite)
- [x] `go vet` on cook/natsapi/cli
- [ ] Manual: `grlx cook <recipe> -T <t> -s <state>`