### PR TITLE
feat(cook): override recipe dir via GRLX_RECIPE_DIR env var

### DIFF
--- a/internal/cook/basepath_test.go
+++ b/internal/cook/basepath_test.go
@@ -1,0 +1,30 @@
+package cook
+
+import (
+	"testing"
+
+	"github.com/gogrlx/grlx/v2/internal/config"
+)
+
+func TestGetBasePathEnvOverride(t *testing.T) {
+	old := config.RecipeDir
+	defer func() { config.RecipeDir = old }()
+	config.RecipeDir = "/srv/grlx/recipes/prod"
+
+	t.Setenv(RecipeDirEnvVar, "/srv/grlx/recipes/feature-branch")
+	if got := getBasePath(); got != "/srv/grlx/recipes/feature-branch" {
+		t.Errorf("expected env override to win, got %q", got)
+	}
+}
+
+func TestGetBasePathFallsBackToConfig(t *testing.T) {
+	old := config.RecipeDir
+	defer func() { config.RecipeDir = old }()
+	config.RecipeDir = "/srv/grlx/recipes/prod"
+
+	// Empty env var must fall back to the configured recipe dir.
+	t.Setenv(RecipeDirEnvVar, "")
+	if got := getBasePath(); got != "/srv/grlx/recipes/prod" {
+		t.Errorf("expected config.RecipeDir fallback, got %q", got)
+	}
+}

--- a/internal/cook/helpers.go
+++ b/internal/cook/helpers.go
@@ -80,7 +80,6 @@ func recipeToStep(id string, recipe map[string]interface{}) (Step, error) {
 }
 
 func collectAllIncludes(sproutID, basepath string, recipeID RecipeName) ([]RecipeName, error) {
-	// TODO get git branch / tag from environment
 	// pass in an ID to a Recipe
 	recipeFilePath, err := ResolveRecipeFilePath(basepath, recipeID)
 	if err != nil {
@@ -209,7 +208,17 @@ func relativeRecipeToAbsolute(basepath, relatedRecipePath string, recipeID Recip
 	return pathToRecipeName(path)
 }
 
+// RecipeDirEnvVar names an optional environment variable that overrides the
+// recipe base path at cook time. This lets an operator point a cook at a
+// different recipe tree — e.g. a checkout of a specific git branch or tag, or
+// a per-environment directory — without rewriting the farmer config. When
+// unset or empty, config.RecipeDir is used.
+const RecipeDirEnvVar = "GRLX_RECIPE_DIR"
+
 func getBasePath() string {
+	if dir := os.Getenv(RecipeDirEnvVar); dir != "" {
+		return dir
+	}
 	return config.RecipeDir
 }
 


### PR DESCRIPTION
## Summary

Adds an environment-variable override (`GRLX_RECIPE_DIR`) for the recipe base path used by cook. This lets an operator point a cook at a different recipe tree — e.g. a checkout of a specific git branch/tag, or a per-environment directory — without rewriting the farmer config. Falls back to `config.RecipeDir` when unset or empty.

Resolves the `// TODO get git branch / tag from environment` in `collectAllIncludes`.

## Scope note
The TODO's broader vision (grlx itself resolving a git branch/tag to a recipe checkout) is an underspecified product decision — checkout mechanism, per-ref subdir layout, credentials, etc. This PR implements the concrete, unambiguous half: honoring an env-provided recipe path, which composes with any external git-checkout step an operator already runs. The fuller in-process git integration is left for a design discussion.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/cook/` (new basepath_test: env override wins, empty falls back to config)