### PR TITLE
docs(test): clarify ping selector resolution is handled upstream

### DIFF
--- a/internal/ingredients/test/ping.go
+++ b/internal/ingredients/test/ping.go
@@ -9,7 +9,11 @@ import (
 	"github.com/gogrlx/grlx/v2/internal/pki"
 )
 
-// TODO allow selector to be more than an ID
+// FPing sends a ping to a single resolved sprout and waits for the pong.
+// Selector expansion (globs, cohorts, "all") is handled upstream by the
+// client's ResolveTargets, which fans a selector out into a TargetedAction
+// with one KeyManager per matched sprout; this function is the per-sprout leg
+// invoked once for each of those targets.
 func FPing(target pki.KeyManager, ping apitypes.PingPong) (apitypes.PingPong, error) {
 	topic := "grlx.sprouts." + target.SproutID + ".test.ping"
 	ping.Ping = true


### PR DESCRIPTION
## Summary

Resolves the stale `// TODO allow selector to be more than an ID` on the internal per-sprout `FPing`.

Investigation shows the selector already supports more than an ID: the CLI client `FPing(target string)` runs `pkiclient.ResolveTargets`, which expands globs, cohorts, and `--all` into a `TargetedAction` carrying one `KeyManager` per matched sprout. The farmer handler fans those out, calling the internal `FPing(target pki.KeyManager, ...)` once per sprout. So the internal function is the per-sprout leg — correct by design — and the TODO is obsolete.

This PR replaces the TODO with an accurate doc comment (no behavior change). Not every TODO needs new code; this one described a capability that already exists upstream.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/ingredients/test/`