### PR TITLE
docs(update): mark self-update as an unwired, unsafe stub

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,6 +1,23 @@
 //go:build self_update
 // +build self_update
 
+// Package selfupdate is an UNWIRED, INCOMPLETE skeleton for binary
+// self-updates. It is gated behind the `self_update` build tag and is not
+// referenced by any grlx binary (the default build uses the no-op variant in
+// noupdate.go). Do NOT enable it as-is:
+//
+//   - CheckForUpdates returns a hardcoded "placeholder" version and therefore
+//     always reports that an update is available.
+//   - PerformUpdate/replaceBinary download and swap the running binary WITHOUT
+//     verifying the release signature or checksum (a remote-code-execution
+//     vector), and replaceBinary's temp-file-then-rename can fail across
+//     filesystems (EXDEV).
+//
+// Implementing this safely requires design decisions (authoritative version
+// source, signature verification against the published checksums.txt(.sig),
+// atomic same-filesystem replace, and rollout policy). Tracked in
+// https://github.com/gogrlx/grlx/issues/286.
+
 package selfupdate
 
 import (


### PR DESCRIPTION
## Summary

The `self_update`-tagged `internal/update` package is an incomplete skeleton wired into nothing (the default build uses the `noupdate.go` no-op). This adds a prominent package doc comment warning that:

- `CheckForUpdates` returns a hardcoded `"placeholder"` and always reports an update available;
- `PerformUpdate`/`replaceBinary` swap the running binary with no signature/checksum verification (RCE vector) and can fail across filesystems (EXDEV).

It points to the tracking issue (#286) that captures the design work — authoritative version source, signature verification against the published `checksums.txt(.sig)`, atomic same-filesystem replace, and rollout policy — required before it can be safely enabled.

No behavior change; documentation only.

## Test plan
- [x] `go build ./...`
- [x] `go build -tags self_update ./internal/update/` and `go vet -tags self_update ./internal/update/`