### PR TITLE
fix(update): stage self-update replacement safely

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -10,12 +10,11 @@
 //     always reports that an update is available.
 //   - PerformUpdate/replaceBinary download and swap the running binary WITHOUT
 //     verifying the release signature or checksum (a remote-code-execution
-//     vector), and replaceBinary's temp-file-then-rename can fail across
-//     filesystems (EXDEV).
+//     vector).
 //
 // Implementing this safely requires design decisions (authoritative version
-// source, signature verification against the published checksums.txt(.sig),
-// atomic same-filesystem replace, and rollout policy). Tracked in
+// source, signature verification against the published checksums.txt(.sig), and
+// rollout policy). Tracked in
 // https://github.com/gogrlx/grlx/issues/286.
 
 package selfupdate
@@ -157,23 +156,84 @@ func (u *Updater) replaceBinary(newBinaryPath string) error {
 		return fmt.Errorf("failed to resolve symlinks: %w", err)
 	}
 
+	return replaceBinaryAt(currentExe, newBinaryPath)
+}
+
+func replaceBinaryAt(currentExe, newBinaryPath string) error {
+	stagedPath, err := stageBinary(currentExe, newBinaryPath)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(stagedPath)
+
+	return commitBinaryUpdate(currentExe, stagedPath)
+}
+
+func stageBinary(currentExe, newBinaryPath string) (string, error) {
+	newBinary, err := os.Open(newBinaryPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open update binary: %w", err)
+	}
+	defer newBinary.Close()
+
+	newBinaryInfo, err := newBinary.Stat()
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect update binary: %w", err)
+	}
+	if newBinaryInfo.IsDir() {
+		return "", fmt.Errorf("update binary is a directory: %s", newBinaryPath)
+	}
+
+	targetDir := filepath.Dir(currentExe)
+	stagedFile, err := os.CreateTemp(targetDir, ".grlx-update-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to stage update in executable directory: %w", err)
+	}
+	stagedPath := stagedFile.Name()
+	removeStaged := true
+	defer func() {
+		if removeStaged {
+			os.Remove(stagedPath)
+		}
+	}()
+
+	if _, err := io.Copy(stagedFile, newBinary); err != nil {
+		stagedFile.Close()
+		return "", fmt.Errorf("failed to stage update binary: %w", err)
+	}
+	if err := stagedFile.Close(); err != nil {
+		return "", fmt.Errorf("failed to close staged update binary: %w", err)
+	}
+	if err := os.Chmod(stagedPath, newBinaryInfo.Mode().Perm()); err != nil {
+		return "", fmt.Errorf("failed to make staged update executable: %w", err)
+	}
+
+	removeStaged = false
+	return stagedPath, nil
+}
+
+func commitBinaryUpdate(currentExe, stagedPath string) error {
 	// Create backup
 	backupPath := currentExe + ".backup"
-	err = os.Rename(currentExe, backupPath)
+	err := os.Rename(currentExe, backupPath)
 	if err != nil {
 		return fmt.Errorf("failed to create backup: %w", err)
 	}
 
 	// Move new binary into place
-	err = os.Rename(newBinaryPath, currentExe)
+	err = os.Rename(stagedPath, currentExe)
 	if err != nil {
 		// Restore backup on failure
-		os.Rename(backupPath, currentExe)
+		if restoreErr := os.Rename(backupPath, currentExe); restoreErr != nil {
+			return fmt.Errorf("failed to install update: %w; failed to restore backup: %w", err, restoreErr)
+		}
 		return fmt.Errorf("failed to install update: %w", err)
 	}
 
 	// Remove backup on success
-	os.Remove(backupPath)
+	if err := os.Remove(backupPath); err != nil {
+		return fmt.Errorf("failed to remove update backup: %w", err)
+	}
 
 	return nil
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,117 @@
+//go:build self_update
+// +build self_update
+
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStageBinaryUsesExecutableDirectory(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	currentExe := filepath.Join(tempDir, "grlx")
+	newBinaryPath := filepath.Join(t.TempDir(), "new-grlx")
+
+	if err := os.WriteFile(currentExe, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newBinaryPath, []byte("new"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	stagedPath, err := stageBinary(currentExe, newBinaryPath)
+	if err != nil {
+		t.Fatalf("stageBinary returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		os.Remove(stagedPath)
+	})
+
+	if filepath.Dir(stagedPath) != filepath.Dir(currentExe) {
+		t.Fatalf("staged binary directory = %q, want %q", filepath.Dir(stagedPath), filepath.Dir(currentExe))
+	}
+
+	contents, err := os.ReadFile(stagedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "new" {
+		t.Fatalf("staged binary contents = %q, want %q", contents, "new")
+	}
+
+	info, err := os.Stat(stagedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("staged binary mode = %v, want %v", got, os.FileMode(0o700))
+	}
+}
+
+func TestCommitBinaryUpdateReplacesCurrentBinary(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	currentExe := filepath.Join(tempDir, "grlx")
+	stagedPath := filepath.Join(tempDir, ".grlx-update-test")
+
+	if err := os.WriteFile(currentExe, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stagedPath, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := commitBinaryUpdate(currentExe, stagedPath); err != nil {
+		t.Fatalf("commitBinaryUpdate returned error: %v", err)
+	}
+
+	contents, err := os.ReadFile(currentExe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "new" {
+		t.Fatalf("current binary contents = %q, want %q", contents, "new")
+	}
+
+	if _, err := os.Stat(currentExe + ".backup"); !os.IsNotExist(err) {
+		t.Fatalf("backup stat error = %v, want not exist", err)
+	}
+}
+
+func TestCommitBinaryUpdateRestoresBackupOnInstallFailure(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	currentExe := filepath.Join(tempDir, "grlx")
+	missingStagedPath := filepath.Join(tempDir, ".missing-update")
+
+	if err := os.WriteFile(currentExe, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := commitBinaryUpdate(currentExe, missingStagedPath)
+	if err == nil {
+		t.Fatal("commitBinaryUpdate returned nil error for missing staged binary")
+	}
+	if !strings.Contains(err.Error(), "failed to install update") {
+		t.Fatalf("commitBinaryUpdate error = %q, want install failure", err)
+	}
+
+	contents, readErr := os.ReadFile(currentExe)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(contents) != "old" {
+		t.Fatalf("current binary contents = %q, want %q", contents, "old")
+	}
+
+	if _, statErr := os.Stat(currentExe + ".backup"); !os.IsNotExist(statErr) {
+		t.Fatalf("backup stat error = %v, want not exist", statErr)
+	}
+}


### PR DESCRIPTION
## Summary

- stage self-update replacements inside the executable directory before swapping, avoiding cross-filesystem rename failures
- restore the original binary if installing the staged replacement fails
- report backup cleanup and rollback failures instead of ignoring them
- add self_update-tagged tests for staging, successful replacement, and rollback

## Validation

- go generate ./...
- go build -tags no_self_update ./...
- go test -tags self_update ./internal/update
- go test -tags no_self_update ./internal/update
- go test -tags no_self_update ./...
- go vet -tags no_self_update ./...
- go test -race -tags self_update ./internal/update
- go test -race -tags no_self_update ./...
- staticcheck -tags no_self_update ./...
- go vet -tags self_update ./internal/update
- staticcheck -tags self_update ./internal/update

Partially addresses #286: this fixes the atomic same-filesystem replace/rollback item only. It intentionally leaves version source, signature verification, and rollout policy unwired.
