### PR TITLE
fix(update): check latest releases with semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260718201538-764159d718ef // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,8 @@ golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 h1:jiDhWWeC7jfWqR9c/uplMOqJ0
 golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90/go.mod h1:xE1HEv6b+1SCZ5/uscMRjUBKtIxworgEcEi+/n9NQDQ=
 golang.org/x/exp v0.0.0-20260718201538-764159d718ef h1:LkZ48HFgy/TvhTI0bcWkjgFkgLyKUwcTbDjS0DUjw+A=
 golang.org/x/exp v0.0.0-20260718201538-764159d718ef/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
+golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
+golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
 golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -6,11 +6,9 @@
 // referenced by any grlx binary (the default build uses the no-op variant in
 // noupdate.go). Do NOT enable it as-is:
 //
-//   - CheckForUpdates returns a hardcoded "placeholder" version and therefore
-//     always reports that an update is available.
-//   - PerformUpdate/replaceBinary download and swap the running binary WITHOUT
-//     verifying the release signature or checksum (a remote-code-execution
-//     vector).
+//   - PerformUpdate downloads and swaps the running binary WITHOUT verifying
+//     the release signature or checksum (a remote-code-execution vector), so it
+//     currently fails closed.
 //
 // Implementing this safely requires design decisions (authoritative version
 // source, signature verification against the published checksums.txt(.sig), and
@@ -21,14 +19,20 @@ package selfupdate
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
+	"strings"
 	"time"
+
+	"golang.org/x/mod/semver"
 )
+
+var errUnsignedUpdatesDisabled = errors.New("self-update install is disabled until release signature verification is implemented")
 
 // UpdateConfig holds the configuration for self-updates
 type UpdateConfig struct {
@@ -56,117 +60,100 @@ func NewUpdater(config UpdateConfig) *Updater {
 
 // CheckForUpdates checks if a newer version is available
 func (u *Updater) CheckForUpdates(ctx context.Context) (string, bool, error) {
-	// Implementation would check against your release API
-	// This is a skeleton - you'll need to implement based on your versioning strategy
-
-	req, err := http.NewRequestWithContext(ctx, "GET", u.config.UpdateURL+"/latest", nil)
+	latestVersion, err := u.fetchLatestVersion(ctx)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to create request: %w", err)
+		return "", false, err
 	}
 
-	resp, err := u.client.Do(req)
+	updateAvailable, err := newerVersion(latestVersion, u.config.CurrentVersion)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to check for updates: %w", err)
+		return "", false, err
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", false, fmt.Errorf("update check failed with status: %d", resp.StatusCode)
-	}
-
-	// Parse response to get latest version
-	// This is a placeholder - implement based on your API response format
-	latestVersion := "placeholder"
-
-	if latestVersion != u.config.CurrentVersion {
+	if updateAvailable {
 		return latestVersion, true, nil
 	}
 
 	return u.config.CurrentVersion, false, nil
 }
 
-// PerformUpdate downloads and installs a new version
-func (u *Updater) PerformUpdate(ctx context.Context, version string) error {
-	downloadURL := fmt.Sprintf("%s/%s/%s-%s-%s-%s",
-		u.config.UpdateURL, version, u.config.BinaryName, version, runtime.GOOS, runtime.GOARCH)
-
-	// Download the new binary
-	tempFile, err := u.downloadBinary(ctx, downloadURL)
-	if err != nil {
-		return fmt.Errorf("failed to download update: %w", err)
+func (u *Updater) fetchLatestVersion(ctx context.Context) (string, error) {
+	if strings.TrimSpace(u.config.UpdateURL) == "" {
+		return "", errors.New("update URL is required")
 	}
-	defer os.Remove(tempFile)
 
-	// Replace the current binary
-	return u.replaceBinary(tempFile)
-}
-
-// downloadBinary downloads the binary to a temporary file
-func (u *Updater) downloadBinary(ctx context.Context, url string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	latestURL := strings.TrimRight(u.config.UpdateURL, "/") + "/latest"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestURL, nil)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 
 	resp, err := u.client.Do(req)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to check for updates: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("download failed with status: %d", resp.StatusCode)
+		return "", fmt.Errorf("update check failed with status: %d", resp.StatusCode)
 	}
 
-	// Create temporary file
-	tempFile, err := os.CreateTemp("", "grlx-update-*")
+	latestVersion, err := parseLatestVersion(resp.Body)
 	if err != nil {
 		return "", err
 	}
-	defer tempFile.Close()
 
-	// Copy the binary
-	_, err = io.Copy(tempFile, resp.Body)
-	if err != nil {
-		os.Remove(tempFile.Name())
-		return "", err
-	}
-
-	// Make it executable
-	err = os.Chmod(tempFile.Name(), 0o755)
-	if err != nil {
-		os.Remove(tempFile.Name())
-		return "", err
-	}
-
-	return tempFile.Name(), nil
+	return latestVersion, nil
 }
 
-// replaceBinary replaces the current binary with the new one
-func (u *Updater) replaceBinary(newBinaryPath string) error {
-	// Get the current executable path
-	currentExe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to get current executable path: %w", err)
+func parseLatestVersion(body io.Reader) (string, error) {
+	var release struct {
+		TagName string `json:"tag_name"`
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(body).Decode(&release); err != nil {
+		return "", fmt.Errorf("failed to parse latest release response: %w", err)
 	}
 
-	// Resolve symlinks
-	currentExe, err = filepath.EvalSymlinks(currentExe)
-	if err != nil {
-		return fmt.Errorf("failed to resolve symlinks: %w", err)
+	for _, candidate := range []string{release.TagName, release.Version, release.Name} {
+		version := canonicalVersion(candidate)
+		if version != "" {
+			return version, nil
+		}
 	}
 
-	return replaceBinaryAt(currentExe, newBinaryPath)
+	return "", errors.New("latest release response did not contain a semantic version")
 }
 
-func replaceBinaryAt(currentExe, newBinaryPath string) error {
-	stagedPath, err := stageBinary(currentExe, newBinaryPath)
-	if err != nil {
-		return err
+func newerVersion(latestVersion, currentVersion string) (bool, error) {
+	latest := canonicalVersion(latestVersion)
+	if latest == "" {
+		return false, fmt.Errorf("latest version %q is not semantic", latestVersion)
 	}
-	defer os.Remove(stagedPath)
 
-	return commitBinaryUpdate(currentExe, stagedPath)
+	current := canonicalVersion(currentVersion)
+	if current == "" {
+		return false, fmt.Errorf("current version %q is not semantic", currentVersion)
+	}
+
+	return semver.Compare(latest, current) > 0, nil
+}
+
+func canonicalVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return ""
+	}
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
+	return semver.Canonical(version)
+}
+
+// PerformUpdate downloads and installs a new version
+func (u *Updater) PerformUpdate(ctx context.Context, version string) error {
+	return errUnsignedUpdatesDisabled
 }
 
 func stageBinary(currentExe, newBinaryPath string) (string, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -4,11 +4,105 @@
 package selfupdate
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestCheckForUpdatesUsesLatestReleaseSemver(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/latest" {
+			t.Fatalf("request path = %q, want /latest", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.3"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	updater := NewUpdater(UpdateConfig{
+		CurrentVersion: "v1.2.2",
+		UpdateURL:      server.URL + "/",
+	})
+
+	version, available, err := updater.CheckForUpdates(context.Background())
+	if err != nil {
+		t.Fatalf("CheckForUpdates returned error: %v", err)
+	}
+	if version != "v1.2.3" {
+		t.Fatalf("version = %q, want v1.2.3", version)
+	}
+	if !available {
+		t.Fatal("available = false, want true")
+	}
+}
+
+func TestCheckForUpdatesDoesNotDowngrade(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.3"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	updater := NewUpdater(UpdateConfig{
+		CurrentVersion: "v1.2.4",
+		UpdateURL:      server.URL,
+	})
+
+	version, available, err := updater.CheckForUpdates(context.Background())
+	if err != nil {
+		t.Fatalf("CheckForUpdates returned error: %v", err)
+	}
+	if version != "v1.2.4" {
+		t.Fatalf("version = %q, want v1.2.4", version)
+	}
+	if available {
+		t.Fatal("available = true, want false")
+	}
+}
+
+func TestParseLatestVersionAcceptsFallbackFields(t *testing.T) {
+	t.Parallel()
+
+	version, err := parseLatestVersion(strings.NewReader(`{"version":"1.2.3"}`))
+	if err != nil {
+		t.Fatalf("parseLatestVersion returned error: %v", err)
+	}
+	if version != "v1.2.3" {
+		t.Fatalf("version = %q, want v1.2.3", version)
+	}
+}
+
+func TestNewerVersionRejectsNonSemver(t *testing.T) {
+	t.Parallel()
+
+	if _, err := newerVersion("placeholder", "v1.2.3"); err == nil {
+		t.Fatal("newerVersion returned nil error for invalid latest version")
+	}
+	if _, err := newerVersion("v1.2.3", "dev"); err == nil {
+		t.Fatal("newerVersion returned nil error for invalid current version")
+	}
+}
+
+func TestPerformUpdateFailsClosedWithoutSignatureVerification(t *testing.T) {
+	t.Parallel()
+
+	updater := NewUpdater(UpdateConfig{})
+	err := updater.PerformUpdate(context.Background(), "v1.2.3")
+	if err == nil {
+		t.Fatal("PerformUpdate returned nil error")
+	}
+	if !strings.Contains(err.Error(), "signature verification") {
+		t.Fatalf("PerformUpdate error = %q, want signature verification failure", err)
+	}
+}
 
 func TestStageBinaryUsesExecutableDirectory(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- replace the self-update placeholder comparison with a `/latest` release response parser
- compare current/latest versions with `golang.org/x/mod/semver` instead of raw string inequality
- fail closed for `PerformUpdate` until checksum/signature verification is implemented
- add tagged self-update tests for latest release checks, semver rejection, and unsigned install failure

Part of #286. This handles the authoritative latest-version/semver portion and avoids making the unsigned installer reachable; checksum/signature verification and CLI wiring remain for follow-up.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go test -tags self_update ./...`
- `go test -race -tags self_update ./internal/update`
- `go vet ./...`
- `go vet -tags self_update ./internal/update`
- `staticcheck ./...`
- `staticcheck -tags self_update ./internal/update`
- `git diff --check`

## Known pre-existing issue

- `go generate ./...` currently fails in the web UI TypeScript tests before this change, with generated API/job route type errors.
