### PR TITLE
feat(file): support HTTP request headers

### DIFF
--- a/internal/ingredients/file/http/provider.go
+++ b/internal/ingredients/file/http/provider.go
@@ -29,9 +29,11 @@ func (hf HTTPFile) Download(ctx context.Context) error {
 			method = m
 		}
 	}
-	// TODO add headers, other body settings, etc here
 	req, err := httpc.NewRequestWithContext(ctx, method, hf.Source, nil)
 	if err != nil {
+		return err
+	}
+	if err := applyRequestHeaders(req, hf.Props["headers"]); err != nil {
 		return err
 	}
 	res, err := httpc.DefaultClient.Do(req)
@@ -64,6 +66,61 @@ func (hf HTTPFile) Download(ctx context.Context) error {
 		return closeErr
 	}
 	return nil
+}
+
+func applyRequestHeaders(req *httpc.Request, headers interface{}) error {
+	if headers == nil {
+		return nil
+	}
+
+	switch typedHeaders := headers.(type) {
+	case map[string]string:
+		for headerName, headerValue := range typedHeaders {
+			req.Header.Set(headerName, headerValue)
+		}
+	case map[string]interface{}:
+		for headerName, rawHeaderValue := range typedHeaders {
+			headerValues, err := normalizeHeaderValues(headerName, rawHeaderValue)
+			if err != nil {
+				return err
+			}
+			setHeaderValues(req.Header, headerName, headerValues)
+		}
+	case httpc.Header:
+		req.Header = typedHeaders.Clone()
+	default:
+		return fmt.Errorf("headers property must be a map, got %T", headers)
+	}
+
+	return nil
+}
+
+func normalizeHeaderValues(headerName string, rawHeaderValue interface{}) ([]string, error) {
+	switch headerValue := rawHeaderValue.(type) {
+	case string:
+		return []string{headerValue}, nil
+	case []string:
+		return headerValue, nil
+	case []interface{}:
+		values := make([]string, 0, len(headerValue))
+		for _, rawValue := range headerValue {
+			value, ok := rawValue.(string)
+			if !ok {
+				return nil, fmt.Errorf("header %q value must contain only strings", headerName)
+			}
+			values = append(values, value)
+		}
+		return values, nil
+	default:
+		return nil, fmt.Errorf("header %q value must be a string or string array", headerName)
+	}
+}
+
+func setHeaderValues(headers httpc.Header, headerName string, headerValues []string) {
+	headers.Del(headerName)
+	for _, headerValue := range headerValues {
+		headers.Add(headerName, headerValue)
+	}
 }
 
 func (hf HTTPFile) Properties() (map[string]interface{}, error) {

--- a/internal/ingredients/file/http/provider_test.go
+++ b/internal/ingredients/file/http/provider_test.go
@@ -101,6 +101,62 @@ func TestDownloadCustomMethod(t *testing.T) {
 	}
 }
 
+func TestDownloadCustomHeaders(t *testing.T) {
+	var authHeader string
+	var acceptedValues []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		acceptedValues = r.Header.Values("X-Accept")
+		w.Write([]byte("headers-ok"))
+	}))
+	defer ts.Close()
+
+	td := t.TempDir()
+	hf := HTTPFile{
+		ID:          "custom-headers",
+		Source:      ts.URL + "/test",
+		Destination: filepath.Join(td, "out"),
+		Props: map[string]interface{}{
+			"headers": map[string]interface{}{
+				"Authorization": "Bearer token",
+				"X-Accept":      []interface{}{"one", "two"},
+			},
+		},
+	}
+
+	if err := hf.Download(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if authHeader != "Bearer token" {
+		t.Errorf("expected Authorization header, got %q", authHeader)
+	}
+	if strings.Join(acceptedValues, ",") != "one,two" {
+		t.Errorf("expected repeated X-Accept headers, got %v", acceptedValues)
+	}
+}
+
+func TestDownloadInvalidHeaders(t *testing.T) {
+	td := t.TempDir()
+	hf := HTTPFile{
+		ID:          "invalid-headers",
+		Source:      "http://example.com/test",
+		Destination: filepath.Join(td, "out"),
+		Props: map[string]interface{}{
+			"headers": map[string]interface{}{
+				"X-Bad": 42,
+			},
+		},
+	}
+
+	err := hf.Download(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid header value")
+	}
+	if !strings.Contains(err.Error(), "X-Bad") {
+		t.Fatalf("expected error to name invalid header, got: %v", err)
+	}
+}
+
 func TestDownloadInvalidMethodProp(t *testing.T) {
 	// Non-string method prop should fall back to GET
 	var receivedMethod string


### PR DESCRIPTION
## Summary
- add `headers` support to the HTTP file provider download path
- accept string, string slice, and decoded YAML/JSON string-array header values
- reject malformed header values before issuing the request

## Validation
- `go generate ./...`
- `go build ./...`
- `go vet ./...`
- `staticcheck ./...`
- `go test -race ./...`