### PR TITLE
refactor(cmd): table-drive command method properties

### DIFF
--- a/internal/ingredients/cmd/cmd.go
+++ b/internal/ingredients/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/gogrlx/grlx/v2/internal/cook"
 	"github.com/gogrlx/grlx/v2/internal/ingredients"
@@ -14,6 +15,18 @@ var ErrCmdMethodUndefined = errors.New("cmd method undefined")
 
 // Compile-time interface check.
 var _ cook.RecipeCooker = Cmd{}
+
+var cmdMethodProps = map[string]ingredients.MethodPropsSet{
+	"run": {
+		ingredients.MethodProps{Key: "name", Type: "string", IsReq: true},
+		ingredients.MethodProps{Key: "args", Type: "string", IsReq: false},
+		ingredients.MethodProps{Key: "env", Type: "[]string", IsReq: false},
+		ingredients.MethodProps{Key: "cwd", Type: "string", IsReq: false},
+		ingredients.MethodProps{Key: "runas", Type: "string", IsReq: false},
+		ingredients.MethodProps{Key: "path", Type: "string", IsReq: false},
+		ingredients.MethodProps{Key: "timeout", Type: "string", IsReq: false},
+	},
+}
 
 type Cmd struct {
 	id     string
@@ -87,26 +100,21 @@ func (c Cmd) Apply(ctx context.Context) (cook.Result, error) {
 	}
 }
 
-// TODO create map for method: type
 func (c Cmd) PropertiesForMethod(method string) (map[string]string, error) {
-	switch method {
-	case "run":
-		return ingredients.MethodPropsSet{
-			ingredients.MethodProps{Key: "name", Type: "string", IsReq: true},
-			ingredients.MethodProps{Key: "args", Type: "string", IsReq: false},
-			ingredients.MethodProps{Key: "env", Type: "[]string", IsReq: false},
-			ingredients.MethodProps{Key: "cwd", Type: "string", IsReq: false},
-			ingredients.MethodProps{Key: "runas", Type: "string", IsReq: false},
-			ingredients.MethodProps{Key: "path", Type: "string", IsReq: false},
-			ingredients.MethodProps{Key: "timeout", Type: "string", IsReq: false},
-		}.ToMap(), nil
-	default:
+	props, ok := cmdMethodProps[method]
+	if !ok {
 		return nil, fmt.Errorf("method %s undefined", method)
 	}
+	return props.ToMap(), nil
 }
 
 func (c Cmd) Methods() (string, []string) {
-	return "cmd", []string{"run"}
+	methods := make([]string, 0, len(cmdMethodProps))
+	for method := range cmdMethodProps {
+		methods = append(methods, method)
+	}
+	sort.Strings(methods)
+	return "cmd", methods
 }
 
 func (c Cmd) Properties() (map[string]interface{}, error) {

--- a/internal/ingredients/cmd/cmd_test.go
+++ b/internal/ingredients/cmd/cmd_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"reflect"
+	"sort"
 	"testing"
 	"time"
 )
@@ -118,6 +120,24 @@ func TestMethods(t *testing.T) {
 	}
 	if len(methods) != 1 || methods[0] != "run" {
 		t.Errorf("expected methods [run], got %v", methods)
+	}
+}
+
+func TestMethodsMatchPropertyDefinitions(t *testing.T) {
+	c := Cmd{}
+	_, methods := c.Methods()
+
+	var definedMethods []string
+	for method := range cmdMethodProps {
+		definedMethods = append(definedMethods, method)
+		if _, err := c.PropertiesForMethod(method); err != nil {
+			t.Fatalf("properties for method %q: %v", method, err)
+		}
+	}
+	sort.Strings(definedMethods)
+
+	if !reflect.DeepEqual(methods, definedMethods) {
+		t.Fatalf("methods = %v, want %v", methods, definedMethods)
 	}
 }
 


### PR DESCRIPTION
## Summary
- centralize command ingredient method property definitions in a dispatch table
- derive Methods() from the same table to keep method registration and properties aligned
- add a regression test that verifies every listed method has properties

## Validation
- go generate ./...
- go test ./internal/ingredients/cmd
- go test ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...

Latest Go checked: go1.26.5