### PR TITLE
fix(sshpicker): guard negative cursor selection

### DIFF
--- a/internal/sshpicker/picker.go
+++ b/internal/sshpicker/picker.go
@@ -76,7 +76,7 @@ func (m Model) View() string {
 
 // Selected returns the selected sprout ID, or empty string if cancelled.
 func (m Model) Selected() string {
-	if m.Cancelled || m.Cursor >= len(m.Sprouts) {
+	if m.Cancelled || m.Cursor < 0 || m.Cursor >= len(m.Sprouts) {
 		return ""
 	}
 	return m.Sprouts[m.Cursor]

--- a/internal/sshpicker/picker_test.go
+++ b/internal/sshpicker/picker_test.go
@@ -216,6 +216,16 @@ func TestSelected_CursorOutOfRange(t *testing.T) {
 	}
 }
 
+func TestSelected_NegativeCursor(t *testing.T) {
+	m := Model{
+		Sprouts: []string{"only"},
+		Cursor:  -1,
+	}
+	if got := m.Selected(); got != "" {
+		t.Fatalf("expected empty for negative cursor, got %q", got)
+	}
+}
+
 func TestView_EmptySprouts(t *testing.T) {
 	m := Model{
 		Cohort:  "empty-cohort",


### PR DESCRIPTION
## Summary
- return an empty selection when the picker cursor is negative
- add regression coverage for negative cursor selection

## Validation
- go generate ./...
- go test ./internal/sshpicker
- go build ./...
- go vet ./...
- staticcheck ./...
- go test ./...
- go test -race -count=1 -timeout=10m ./...

Note: latest Go check was not needed; this PR does not change go.mod or go.sum.