### PR TITLE
fix(update): reject missing check interval

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -32,7 +32,10 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-var errUnsignedUpdatesDisabled = errors.New("self-update install is disabled until release signature verification is implemented")
+var (
+	errUnsignedUpdatesDisabled = errors.New("self-update install is disabled until release signature verification is implemented")
+	errUpdateIntervalRequired  = errors.New("self-update check interval must be greater than zero")
+)
 
 // UpdateConfig holds the configuration for self-updates
 type UpdateConfig struct {
@@ -227,6 +230,13 @@ func commitBinaryUpdate(currentExe, stagedPath string) error {
 
 // StartUpdateChecker starts a background goroutine that periodically checks for updates
 func (u *Updater) StartUpdateChecker(ctx context.Context, callback func(version string, available bool, err error)) {
+	if u.config.CheckInterval <= 0 {
+		if callback != nil {
+			callback("", false, errUpdateIntervalRequired)
+		}
+		return
+	}
+
 	ticker := time.NewTicker(u.config.CheckInterval)
 	defer ticker.Stop()
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -5,6 +5,7 @@ package selfupdate
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -101,6 +102,30 @@ func TestPerformUpdateFailsClosedWithoutSignatureVerification(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "signature verification") {
 		t.Fatalf("PerformUpdate error = %q, want signature verification failure", err)
+	}
+}
+
+func TestStartUpdateCheckerRejectsMissingInterval(t *testing.T) {
+	t.Parallel()
+
+	updater := NewUpdater(UpdateConfig{})
+	called := false
+
+	updater.StartUpdateChecker(context.Background(), func(version string, available bool, err error) {
+		called = true
+		if version != "" {
+			t.Fatalf("version = %q, want empty", version)
+		}
+		if available {
+			t.Fatal("available = true, want false")
+		}
+		if !errors.Is(err, errUpdateIntervalRequired) {
+			t.Fatalf("error = %v, want %v", err, errUpdateIntervalRequired)
+		}
+	})
+
+	if !called {
+		t.Fatal("callback was not called")
 	}
 }
 


### PR DESCRIPTION
## Summary
- guard self-update checker against zero or negative check intervals
- report the configuration error through the callback instead of panicking in time.NewTicker
- add a self_update build-tag regression test

## Tests
- go generate ./...
- go test -race ./...
- go test -race -tags self_update ./internal/update
- go vet ./...
- staticcheck ./...
- go build ./...