### PR TITLE
fix(update): verify self-update artifact checksums

### DIFF
--- a/internal/update/noupdate.go
+++ b/internal/update/noupdate.go
@@ -13,6 +13,7 @@ import (
 type UpdateConfig struct {
 	CurrentVersion string
 	BinaryName     string
+	ChecksumName   string
 	UpdateURL      string
 	CheckInterval  time.Duration
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -18,7 +18,10 @@
 package selfupdate
 
 import (
+	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,6 +44,7 @@ var (
 type UpdateConfig struct {
 	CurrentVersion string
 	BinaryName     string
+	ChecksumName   string
 	UpdateURL      string
 	CheckInterval  time.Duration
 }
@@ -157,6 +161,66 @@ func canonicalVersion(version string) string {
 // PerformUpdate downloads and installs a new version
 func (u *Updater) PerformUpdate(ctx context.Context, version string) error {
 	return errUnsignedUpdatesDisabled
+}
+
+func (u *Updater) checksumName() string {
+	if strings.TrimSpace(u.config.ChecksumName) != "" {
+		return strings.TrimSpace(u.config.ChecksumName)
+	}
+
+	return filepath.Base(u.config.BinaryName)
+}
+
+func verifyArtifactChecksum(checksums io.Reader, artifact io.Reader, artifactName string) error {
+	expectedChecksum, err := checksumForArtifact(checksums, artifactName)
+	if err != nil {
+		return err
+	}
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, artifact); err != nil {
+		return fmt.Errorf("failed to hash update artifact: %w", err)
+	}
+
+	actualChecksum := hex.EncodeToString(hasher.Sum(nil))
+	if actualChecksum != expectedChecksum {
+		return fmt.Errorf("update artifact checksum mismatch for %s", artifactName)
+	}
+
+	return nil
+}
+
+func checksumForArtifact(checksums io.Reader, artifactName string) (string, error) {
+	artifactName = strings.TrimSpace(artifactName)
+	if artifactName == "" {
+		return "", errors.New("update artifact name is required")
+	}
+
+	scanner := bufio.NewScanner(checksums)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 {
+			continue
+		}
+
+		checksum := strings.ToLower(strings.TrimSpace(fields[0]))
+		if len(checksum) != sha256.Size*2 {
+			continue
+		}
+		if _, err := hex.DecodeString(checksum); err != nil {
+			continue
+		}
+
+		name := strings.TrimPrefix(fields[1], "*")
+		if name == artifactName || filepath.Base(name) == artifactName {
+			return checksum, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read update checksums: %w", err)
+	}
+
+	return "", fmt.Errorf("checksum for update artifact %s not found", artifactName)
 }
 
 func stageBinary(currentExe, newBinaryPath string) (string, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -5,7 +5,9 @@ package selfupdate
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -102,6 +104,97 @@ func TestPerformUpdateFailsClosedWithoutSignatureVerification(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "signature verification") {
 		t.Fatalf("PerformUpdate error = %q, want signature verification failure", err)
+	}
+}
+
+func TestChecksumNameUsesExplicitConfig(t *testing.T) {
+	t.Parallel()
+
+	updater := NewUpdater(UpdateConfig{
+		BinaryName:   "/usr/local/bin/grlx",
+		ChecksumName: "grlx-v1.2.3-linux-amd64",
+	})
+
+	if got := updater.checksumName(); got != "grlx-v1.2.3-linux-amd64" {
+		t.Fatalf("checksumName() = %q, want grlx-v1.2.3-linux-amd64", got)
+	}
+}
+
+func TestChecksumNameDefaultsToBinaryBase(t *testing.T) {
+	t.Parallel()
+
+	updater := NewUpdater(UpdateConfig{BinaryName: "/usr/local/bin/grlx"})
+
+	if got := updater.checksumName(); got != "grlx" {
+		t.Fatalf("checksumName() = %q, want grlx", got)
+	}
+}
+
+func TestVerifyArtifactChecksumAcceptsMatchingChecksum(t *testing.T) {
+	t.Parallel()
+
+	artifact := "new binary"
+	checksum := sha256.Sum256([]byte(artifact))
+	manifest := fmt.Sprintf("%x  dist/grlx-v1.2.3-linux-amd64\n", checksum)
+
+	err := verifyArtifactChecksum(strings.NewReader(manifest), strings.NewReader(artifact), "grlx-v1.2.3-linux-amd64")
+	if err != nil {
+		t.Fatalf("verifyArtifactChecksum returned error: %v", err)
+	}
+}
+
+func TestVerifyArtifactChecksumRejectsMismatch(t *testing.T) {
+	t.Parallel()
+
+	checksum := sha256.Sum256([]byte("expected binary"))
+	manifest := fmt.Sprintf("%x  grlx-v1.2.3-linux-amd64\n", checksum)
+
+	err := verifyArtifactChecksum(strings.NewReader(manifest), strings.NewReader("different binary"), "grlx-v1.2.3-linux-amd64")
+	if err == nil {
+		t.Fatal("verifyArtifactChecksum returned nil error for mismatched artifact")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("verifyArtifactChecksum error = %q, want checksum mismatch", err)
+	}
+}
+
+func TestChecksumForArtifactRejectsMissingName(t *testing.T) {
+	t.Parallel()
+
+	_, err := checksumForArtifact(strings.NewReader(""), "")
+	if err == nil {
+		t.Fatal("checksumForArtifact returned nil error for missing artifact name")
+	}
+}
+
+func TestChecksumForArtifactRejectsMissingChecksum(t *testing.T) {
+	t.Parallel()
+
+	checksum := sha256.Sum256([]byte("other binary"))
+	manifest := fmt.Sprintf("%x  grlx-v1.2.3-darwin-amd64\n", checksum)
+
+	_, err := checksumForArtifact(strings.NewReader(manifest), "grlx-v1.2.3-linux-amd64")
+	if err == nil {
+		t.Fatal("checksumForArtifact returned nil error for missing checksum")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("checksumForArtifact error = %q, want not found", err)
+	}
+}
+
+func TestChecksumForArtifactIgnoresMalformedEntries(t *testing.T) {
+	t.Parallel()
+
+	artifact := "new binary"
+	checksum := sha256.Sum256([]byte(artifact))
+	manifest := fmt.Sprintf("not-a-checksum  grlx-v1.2.3-linux-amd64\n%x  *grlx-v1.2.3-linux-amd64\n", checksum)
+
+	got, err := checksumForArtifact(strings.NewReader(manifest), "grlx-v1.2.3-linux-amd64")
+	if err != nil {
+		t.Fatalf("checksumForArtifact returned error: %v", err)
+	}
+	if want := fmt.Sprintf("%x", checksum); got != want {
+		t.Fatalf("checksumForArtifact = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add SHA-256 checksum manifest parsing for self-update artifacts
- allow self-update config to specify the checksum manifest artifact name separately from the installed binary path
- cover checksum success, mismatch, missing entry, malformed entry, and config fallback behavior under the `self_update` build tag

## Verification
- go test ./internal/update
- go test -tags self_update ./internal/update
- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...
- go test -race -tags self_update ./internal/update

Refs #286