### PR TITLE
fix(update): preserve existing update backups

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -203,10 +203,12 @@ func stageBinary(currentExe, newBinaryPath string) (string, error) {
 }
 
 func commitBinaryUpdate(currentExe, stagedPath string) error {
-	// Create backup
-	backupPath := currentExe + ".backup"
-	err := os.Rename(currentExe, backupPath)
+	backupPath, err := backupPathFor(currentExe)
 	if err != nil {
+		return err
+	}
+
+	if err := os.Rename(currentExe, backupPath); err != nil {
 		return fmt.Errorf("failed to create backup: %w", err)
 	}
 
@@ -226,6 +228,26 @@ func commitBinaryUpdate(currentExe, stagedPath string) error {
 	}
 
 	return nil
+}
+
+func backupPathFor(currentExe string) (string, error) {
+	targetDir := filepath.Dir(currentExe)
+	targetName := filepath.Base(currentExe)
+
+	backupFile, err := os.CreateTemp(targetDir, targetName+".backup-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to reserve update backup path: %w", err)
+	}
+	backupPath := backupFile.Name()
+	if err := backupFile.Close(); err != nil {
+		os.Remove(backupPath)
+		return "", fmt.Errorf("failed to close update backup placeholder: %w", err)
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return "", fmt.Errorf("failed to clear update backup placeholder: %w", err)
+	}
+
+	return backupPath, nil
 }
 
 // StartUpdateChecker starts a background goroutine that periodically checks for updates

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -198,8 +198,12 @@ func TestCommitBinaryUpdateReplacesCurrentBinary(t *testing.T) {
 		t.Fatalf("current binary contents = %q, want %q", contents, "new")
 	}
 
-	if _, err := os.Stat(currentExe + ".backup"); !os.IsNotExist(err) {
-		t.Fatalf("backup stat error = %v, want not exist", err)
+	matches, err := filepath.Glob(currentExe + ".backup-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("backup files = %v, want none", matches)
 	}
 }
 
@@ -230,7 +234,40 @@ func TestCommitBinaryUpdateRestoresBackupOnInstallFailure(t *testing.T) {
 		t.Fatalf("current binary contents = %q, want %q", contents, "old")
 	}
 
-	if _, statErr := os.Stat(currentExe + ".backup"); !os.IsNotExist(statErr) {
-		t.Fatalf("backup stat error = %v, want not exist", statErr)
+	matches, err := filepath.Glob(currentExe + ".backup-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("backup files = %v, want none", matches)
+	}
+}
+
+func TestCommitBinaryUpdateDoesNotClobberExistingBackup(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	currentExe := filepath.Join(tempDir, "grlx")
+	existingBackup := currentExe + ".backup"
+	missingStagedPath := filepath.Join(tempDir, ".missing-update")
+
+	if err := os.WriteFile(currentExe, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(existingBackup, []byte("previous backup"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := commitBinaryUpdate(currentExe, missingStagedPath)
+	if err == nil {
+		t.Fatal("commitBinaryUpdate returned nil error for missing staged binary")
+	}
+
+	contents, err := os.ReadFile(existingBackup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "previous backup" {
+		t.Fatalf("existing backup contents = %q, want %q", contents, "previous backup")
 	}
 }


### PR DESCRIPTION
## Summary
- reserve a unique same-directory backup path before committing self-update binaries
- avoid clobbering an existing grlx.backup file during failed installs
- update rollback tests to assert temporary backups are cleaned up

## Verification
- latest Go checked before work: go1.26.5
- go generate ./...
- go test ./internal/update
- go test -tags self_update ./internal/update
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...
- go test -race -tags self_update ./internal/update

Refs #286