### PR TITLE
fix(api): reject malformed ping actions

### DIFF
--- a/internal/api/handlers/ingredients/test/ping.go
+++ b/internal/api/handlers/ingredients/test/ping.go
@@ -25,7 +25,12 @@ func HTestPing(w http.ResponseWriter, r *http.Request) {
 	}
 	jw, _ := json.Marshal(targetAction.Action)
 	var ping apitypes.PingPong
-	json.NewDecoder(bytes.NewBuffer(jw)).Decode(&ping)
+	err = json.NewDecoder(bytes.NewBuffer(jw)).Decode(&ping)
+	if err != nil {
+		log.Trace("An invalid ping request was made.")
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	// verify our sprout id is valid
 	for _, target := range targetAction.Target {

--- a/internal/api/handlers/ingredients/test/ping_test.go
+++ b/internal/api/handlers/ingredients/test/ping_test.go
@@ -82,6 +82,18 @@ func TestHTestPing_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestHTestPing_InvalidAction(t *testing.T) {
+	body := []byte(`{"target":[{"id":"sprout1"}],"action":"not-a-ping-object"}`)
+	req := httptest.NewRequest(http.MethodPost, "/test/ping", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	HTestPing(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestHTestPing_InvalidSproutID(t *testing.T) {
 	setupPingTestPKI(t)
 


### PR DESCRIPTION
## Summary
- reject malformed `/test/ping` action payloads instead of silently using a zero-value ping request
- add coverage matching the command-run handler's malformed action behavior

## Tests
- `go generate ./...`
- `go build ./...`
- `go vet ./...`
- `staticcheck ./...`
- `go test -race ./...`
