### PR TITLE
fix(update): reject unstable self-update releases

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -110,12 +110,20 @@ func (u *Updater) fetchLatestVersion(ctx context.Context) (string, error) {
 
 func parseLatestVersion(body io.Reader) (string, error) {
 	var release struct {
-		TagName string `json:"tag_name"`
-		Name    string `json:"name"`
-		Version string `json:"version"`
+		TagName    string `json:"tag_name"`
+		Name       string `json:"name"`
+		Version    string `json:"version"`
+		Draft      bool   `json:"draft"`
+		Prerelease bool   `json:"prerelease"`
 	}
 	if err := json.NewDecoder(body).Decode(&release); err != nil {
 		return "", fmt.Errorf("failed to parse latest release response: %w", err)
+	}
+	if release.Draft {
+		return "", errors.New("latest release response is a draft")
+	}
+	if release.Prerelease {
+		return "", errors.New("latest release response is a prerelease")
 	}
 
 	for _, candidate := range []string{release.TagName, release.Version, release.Name} {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -81,6 +81,41 @@ func TestParseLatestVersionAcceptsFallbackFields(t *testing.T) {
 	}
 }
 
+func TestParseLatestVersionRejectsUnstableReleases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "draft",
+			body: `{"tag_name":"v1.2.3","draft":true}`,
+			want: "draft",
+		},
+		{
+			name: "prerelease",
+			body: `{"tag_name":"v1.2.3","prerelease":true}`,
+			want: "prerelease",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseLatestVersion(strings.NewReader(test.body))
+			if err == nil {
+				t.Fatal("parseLatestVersion returned nil error")
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("parseLatestVersion error = %q, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestNewerVersionRejectsNonSemver(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- reject latest-release responses marked as draft before reporting an update
- reject latest-release responses marked as prerelease before reporting an update
- add self_update parser coverage for both unstable release states

## Verification
- go test ./...
- go test -tags self_update ./internal/update
- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...
- go test -race -tags self_update ./internal/update

Refs #286