### PR TITLE
fix(update): bound latest release metadata parsing

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -37,6 +37,8 @@ var (
 	errUpdateIntervalRequired  = errors.New("self-update check interval must be greater than zero")
 )
 
+const maxLatestReleaseResponseBytes = 1 << 20
+
 // UpdateConfig holds the configuration for self-updates
 type UpdateConfig struct {
 	CurrentVersion string
@@ -109,12 +111,20 @@ func (u *Updater) fetchLatestVersion(ctx context.Context) (string, error) {
 }
 
 func parseLatestVersion(body io.Reader) (string, error) {
+	contents, err := io.ReadAll(io.LimitReader(body, maxLatestReleaseResponseBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("failed to read latest release response: %w", err)
+	}
+	if len(contents) > maxLatestReleaseResponseBytes {
+		return "", fmt.Errorf("latest release response exceeds %d bytes", maxLatestReleaseResponseBytes)
+	}
+
 	var release struct {
 		TagName string `json:"tag_name"`
 		Name    string `json:"name"`
 		Version string `json:"version"`
 	}
-	if err := json.NewDecoder(body).Decode(&release); err != nil {
+	if err := json.Unmarshal(contents, &release); err != nil {
 		return "", fmt.Errorf("failed to parse latest release response: %w", err)
 	}
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -81,6 +81,19 @@ func TestParseLatestVersionAcceptsFallbackFields(t *testing.T) {
 	}
 }
 
+func TestParseLatestVersionRejectsOversizedResponse(t *testing.T) {
+	t.Parallel()
+
+	body := strings.NewReader(strings.Repeat(" ", maxLatestReleaseResponseBytes+1))
+	_, err := parseLatestVersion(body)
+	if err == nil {
+		t.Fatal("parseLatestVersion returned nil error for oversized response")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("parseLatestVersion error = %q, want size limit failure", err)
+	}
+}
+
 func TestNewerVersionRejectsNonSemver(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- cap self-update latest-release metadata responses at 1 MiB before parsing JSON
- switch parsing to an explicit bounded read plus json.Unmarshal
- cover oversized metadata rejection in self_update tests

## Tests
- go generate ./...
- go test -race ./...
- go test -race -tags self_update ./...
- go vet ./...
- staticcheck ./...