### PR TITLE
fix(file): stage HTTP downloads before replace

### DIFF
--- a/internal/ingredients/file/http/provider.go
+++ b/internal/ingredients/file/http/provider.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	httpc "net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/gogrlx/grlx/v2/internal/ingredients/file"
 	"github.com/gogrlx/grlx/v2/internal/ingredients/file/hashers"
@@ -18,6 +19,8 @@ type HTTPFile struct {
 	Hash        string
 	Props       map[string]interface{}
 }
+
+const downloadTempPattern = ".grlx-http-download-*"
 
 // Compile-time interface check.
 var _ file.FileProvider = HTTPFile{}
@@ -51,20 +54,31 @@ func (hf HTTPFile) Download(ctx context.Context) error {
 		// TODO standardize this error message
 		return fmt.Errorf("unexpected HTTP status code %d", res.StatusCode)
 	}
-	dest, err := os.Create(hf.Destination)
+	destinationDir := filepath.Dir(hf.Destination)
+	stagedFile, err := os.CreateTemp(destinationDir, downloadTempPattern)
 	if err != nil {
 		return err
 	}
-	_, copyErr := io.Copy(dest, res.Body)
-	closeErr := dest.Close()
+	stagedPath := stagedFile.Name()
+	cleanupStaged := true
+	defer func() {
+		if cleanupStaged {
+			os.Remove(stagedPath)
+		}
+	}()
+
+	_, copyErr := io.Copy(stagedFile, res.Body)
+	closeErr := stagedFile.Close()
 	if copyErr != nil {
-		os.Remove(hf.Destination)
 		return copyErr
 	}
 	if closeErr != nil {
-		os.Remove(hf.Destination)
 		return closeErr
 	}
+	if err := os.Rename(stagedPath, hf.Destination); err != nil {
+		return err
+	}
+	cleanupStaged = false
 	return nil
 }
 

--- a/internal/ingredients/file/http/provider_test.go
+++ b/internal/ingredients/file/http/provider_test.go
@@ -252,6 +252,79 @@ func TestDownloadUnexpectedStatusCode(t *testing.T) {
 	}
 }
 
+func TestDownloadCopyFailureKeepsExistingDestination(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("partial"))
+	}))
+	defer ts.Close()
+
+	td := t.TempDir()
+	dest := filepath.Join(td, "out")
+	if err := os.WriteFile(dest, []byte("existing"), 0644); err != nil {
+		t.Fatalf("failed to write existing destination: %v", err)
+	}
+
+	hf := HTTPFile{
+		ID:          "partial",
+		Source:      ts.URL + "/partial",
+		Destination: dest,
+		Props:       map[string]interface{}{},
+	}
+	err := hf.Download(context.Background())
+	if err == nil {
+		t.Fatal("expected error for truncated response body")
+	}
+
+	data, readErr := os.ReadFile(dest)
+	if readErr != nil {
+		t.Fatalf("failed to read destination: %v", readErr)
+	}
+	if string(data) != "existing" {
+		t.Fatalf("destination = %q, want existing", data)
+	}
+
+	matches, globErr := filepath.Glob(filepath.Join(td, downloadTempPattern))
+	if globErr != nil {
+		t.Fatalf("failed to glob temp files: %v", globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected staged download cleanup, found %v", matches)
+	}
+}
+
+func TestDownloadSuccessReplacesExistingDestination(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("replacement"))
+	}))
+	defer ts.Close()
+
+	td := t.TempDir()
+	dest := filepath.Join(td, "out")
+	if err := os.WriteFile(dest, []byte("existing"), 0644); err != nil {
+		t.Fatalf("failed to write existing destination: %v", err)
+	}
+
+	hf := HTTPFile{
+		ID:          "replace",
+		Source:      ts.URL + "/replace",
+		Destination: dest,
+		Props:       map[string]interface{}{},
+	}
+	if err := hf.Download(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("failed to read destination: %v", err)
+	}
+	if string(data) != "replacement" {
+		t.Fatalf("destination = %q, want replacement", data)
+	}
+}
+
 func TestDownloadCustomExpectedCode(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
## Summary
- write HTTP file downloads to a staged temp file in the destination directory
- rename staged downloads into place only after copy and close succeed
- add regression coverage for truncated responses preserving existing destination files and cleaning temp files

## Validation
- go test ./internal/ingredients/file/http
- go test -race ./internal/ingredients/file/http
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...

## Note
- go generate ./... still fails before/after this change because /home/tai/code/foss/grlx-web-ui is on cd/openapi-codegen with TypeScript errors in generated/types.test.ts and jobs..test.tsx.