### PR TITLE
fix(update): verify downloaded binary checksums

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -18,7 +18,10 @@
 package selfupdate
 
 import (
+	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -157,6 +160,63 @@ func canonicalVersion(version string) string {
 // PerformUpdate downloads and installs a new version
 func (u *Updater) PerformUpdate(ctx context.Context, version string) error {
 	return errUnsignedUpdatesDisabled
+}
+
+func verifyBinaryChecksum(binaryPath string, checksums io.Reader) error {
+	expectedChecksum, err := checksumForBinary(filepath.Base(binaryPath), checksums)
+	if err != nil {
+		return err
+	}
+
+	binary, err := os.Open(binaryPath)
+	if err != nil {
+		return fmt.Errorf("failed to open update binary for checksum verification: %w", err)
+	}
+	defer binary.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, binary); err != nil {
+		return fmt.Errorf("failed to checksum update binary: %w", err)
+	}
+
+	actualChecksum := hex.EncodeToString(hasher.Sum(nil))
+	if actualChecksum != expectedChecksum {
+		return fmt.Errorf("update binary checksum mismatch for %s", filepath.Base(binaryPath))
+	}
+
+	return nil
+}
+
+func checksumForBinary(binaryName string, checksums io.Reader) (string, error) {
+	scanner := bufio.NewScanner(checksums)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) != 2 {
+			return "", fmt.Errorf("malformed checksum line for %s", binaryName)
+		}
+
+		checksum := fields[0]
+		name := strings.TrimPrefix(fields[1], "*")
+		if filepath.Base(name) != binaryName {
+			continue
+		}
+		if len(checksum) != sha256.Size*2 {
+			return "", fmt.Errorf("malformed SHA256 checksum for %s", binaryName)
+		}
+		if _, err := hex.DecodeString(checksum); err != nil {
+			return "", fmt.Errorf("malformed SHA256 checksum for %s: %w", binaryName, err)
+		}
+
+		return strings.ToLower(checksum), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read checksums: %w", err)
+	}
+
+	return "", fmt.Errorf("checksum entry not found for %s", binaryName)
 }
 
 func stageBinary(currentExe, newBinaryPath string) (string, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -5,7 +5,9 @@ package selfupdate
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -126,6 +128,76 @@ func TestStartUpdateCheckerRejectsMissingInterval(t *testing.T) {
 
 	if !called {
 		t.Fatal("callback was not called")
+	}
+}
+
+func TestVerifyBinaryChecksumAcceptsMatchingEntry(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := filepath.Join(t.TempDir(), "grlx")
+	contents := []byte("verified binary")
+	if err := os.WriteFile(binaryPath, contents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	checksum := fmt.Sprintf("%x", sha256.Sum256(contents))
+	checksums := strings.NewReader("abcd unrelated\n" + checksum + "  grlx\n")
+
+	if err := verifyBinaryChecksum(binaryPath, checksums); err != nil {
+		t.Fatalf("verifyBinaryChecksum returned error: %v", err)
+	}
+}
+
+func TestVerifyBinaryChecksumRejectsMismatch(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := filepath.Join(t.TempDir(), "grlx")
+	if err := os.WriteFile(binaryPath, []byte("actual"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	checksum := fmt.Sprintf("%x", sha256.Sum256([]byte("different")))
+	err := verifyBinaryChecksum(binaryPath, strings.NewReader(checksum+"  grlx\n"))
+	if err == nil {
+		t.Fatal("verifyBinaryChecksum returned nil error for checksum mismatch")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("verifyBinaryChecksum error = %q, want checksum mismatch", err)
+	}
+}
+
+func TestVerifyBinaryChecksumRejectsMissingEntry(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := filepath.Join(t.TempDir(), "grlx")
+	if err := os.WriteFile(binaryPath, []byte("actual"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	checksum := fmt.Sprintf("%x", sha256.Sum256([]byte("actual")))
+	err := verifyBinaryChecksum(binaryPath, strings.NewReader(checksum+"  sprout\n"))
+	if err == nil {
+		t.Fatal("verifyBinaryChecksum returned nil error for missing checksum entry")
+	}
+	if !strings.Contains(err.Error(), "checksum entry not found") {
+		t.Fatalf("verifyBinaryChecksum error = %q, want missing entry", err)
+	}
+}
+
+func TestVerifyBinaryChecksumRejectsMalformedChecksum(t *testing.T) {
+	t.Parallel()
+
+	binaryPath := filepath.Join(t.TempDir(), "grlx")
+	if err := os.WriteFile(binaryPath, []byte("actual"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := verifyBinaryChecksum(binaryPath, strings.NewReader("not-a-sha256  grlx\n"))
+	if err == nil {
+		t.Fatal("verifyBinaryChecksum returned nil error for malformed checksum")
+	}
+	if !strings.Contains(err.Error(), "malformed SHA256 checksum") {
+		t.Fatalf("verifyBinaryChecksum error = %q, want malformed checksum", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a self-update helper that verifies a staged binary against a SHA256 entry from checksums.txt
- reject checksum mismatches, missing entries, and malformed checksum rows
- keep PerformUpdate failed closed until signature verification is implemented

## Tests
- go generate ./...
- go test -tags self_update ./internal/update
- go test -race ./internal/update
- go test -race ./...
- staticcheck ./...