### PR TITLE
fix(file): stage HTTP downloads before replace

### DIFF
--- a/internal/ingredients/file/http/provider.go
+++ b/internal/ingredients/file/http/provider.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	httpc "net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/gogrlx/grlx/v2/internal/ingredients/file"
 	"github.com/gogrlx/grlx/v2/internal/ingredients/file/hashers"
@@ -51,19 +52,26 @@ func (hf HTTPFile) Download(ctx context.Context) error {
 		// TODO standardize this error message
 		return fmt.Errorf("unexpected HTTP status code %d", res.StatusCode)
 	}
-	dest, err := os.Create(hf.Destination)
+	destDir := filepath.Dir(hf.Destination)
+	destName := filepath.Base(hf.Destination)
+	dest, err := os.CreateTemp(destDir, "."+destName+"-*")
 	if err != nil {
 		return err
 	}
+	tempName := dest.Name()
 	_, copyErr := io.Copy(dest, res.Body)
 	closeErr := dest.Close()
 	if copyErr != nil {
-		os.Remove(hf.Destination)
+		os.Remove(tempName)
 		return copyErr
 	}
 	if closeErr != nil {
-		os.Remove(hf.Destination)
+		os.Remove(tempName)
 		return closeErr
+	}
+	if err := os.Rename(tempName, hf.Destination); err != nil {
+		os.Remove(tempName)
+		return err
 	}
 	return nil
 }

--- a/internal/ingredients/file/http/provider_test.go
+++ b/internal/ingredients/file/http/provider_test.go
@@ -252,6 +252,74 @@ func TestDownloadUnexpectedStatusCode(t *testing.T) {
 	}
 }
 
+func TestDownloadCopyErrorDoesNotLeavePartialDestination(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "128")
+		if _, err := w.Write([]byte("partial")); err != nil {
+			t.Fatalf("failed to write partial response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	td := t.TempDir()
+	dest := filepath.Join(td, "out")
+	hf := HTTPFile{
+		ID:          "short-body",
+		Source:      ts.URL + "/short",
+		Destination: dest,
+		Props:       map[string]interface{}{},
+	}
+
+	err := hf.Download(context.Background())
+	if err == nil {
+		t.Fatal("expected error for truncated response body")
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("destination should not exist after failed download, stat error: %v", statErr)
+	}
+	matches, err := filepath.Glob(filepath.Join(td, ".out-*"))
+	if err != nil {
+		t.Fatalf("failed to glob temporary files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary download files were not cleaned up: %v", matches)
+	}
+}
+
+func TestDownloadCopyErrorPreservesExistingDestination(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "128")
+		if _, err := w.Write([]byte("partial")); err != nil {
+			t.Fatalf("failed to write partial response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	td := t.TempDir()
+	dest := filepath.Join(td, "out")
+	if err := os.WriteFile(dest, []byte("current"), 0644); err != nil {
+		t.Fatalf("failed to write existing destination: %v", err)
+	}
+	hf := HTTPFile{
+		ID:          "short-body-existing",
+		Source:      ts.URL + "/short",
+		Destination: dest,
+		Props:       map[string]interface{}{},
+	}
+
+	err := hf.Download(context.Background())
+	if err == nil {
+		t.Fatal("expected error for truncated response body")
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("failed to read existing destination: %v", err)
+	}
+	if string(data) != "current" {
+		t.Fatalf("destination content = %q, want current", data)
+	}
+}
+
 func TestDownloadCustomExpectedCode(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
## Summary

- Stage HTTP file downloads in a temporary file in the destination directory.
- Rename the completed temporary file into place only after body copy and close succeed.
- Add regression coverage for truncated responses, including preserving an existing destination.

## Validation

- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...
