### PR TITLE
fix(client): inject tokens after JSON whitespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
 
       - name: Download modules
         run: go mod download
@@ -55,7 +56,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: stable
+          go-version: 1.26.x
+          check-latest: true
 
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@v1

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,5 +16,6 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
+           go-version-input: '1.26.x'
            go-version-file: 'go.mod'
            go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gogrlx/grlx/v2
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/mattn/go-localereader v0.0.1 => github.com/taigrr/go-localereader v0.0.2
 
@@ -57,7 +57,7 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.1 // indirect
-	github.com/go-git/go-git/v5 v5.19.1 // indirect
+	github.com/go-git/go-git/v5 v5.19.2 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/go-git/go-billy/v5 v5.9.1 h1:8U73XiOTfINdItHVa6z4Gv7ToObcZ6grkqQbLryL
 github.com/go-git/go-billy/v5 v5.9.1/go.mod h1:ExsU+jcGwXTBOnyilvAnEM1wug1IxHr4yP2ZXsNRtV0=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
-github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
+github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-logfmt/logfmt v0.6.1 h1:4hvbpePJKnIzH1B+8OR/JPbTx37NktoI9LE2QZBBkvE=
 github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/z6CO0XAk=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/internal/api/client/inject_test.go
+++ b/internal/api/client/inject_test.go
@@ -2,7 +2,12 @@ package client
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/nats-io/nkeys"
+	"github.com/taigrr/jety"
 )
 
 func TestInjectToken_NilPayload(t *testing.T) {
@@ -49,6 +54,28 @@ func TestInjectToken_ExistingJSON(t *testing.T) {
 	}
 }
 
+func TestInjectToken_ExistingJSONWithLeadingWhitespace(t *testing.T) {
+	setupTokenInjectionTest(t)
+
+	input := []byte("\n\t {\"limit\":10,\"sprout_id\":\"web-01\"}")
+	got := injectToken(input)
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(got, &obj); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	if obj["token"] == "" {
+		t.Fatal("expected token to be injected")
+	}
+	if obj["limit"] != float64(10) {
+		t.Errorf("expected limit=10, got %v", obj["limit"])
+	}
+	if obj["sprout_id"] != "web-01" {
+		t.Errorf("expected sprout_id=web-01, got %v", obj["sprout_id"])
+	}
+}
+
 func TestInjectToken_NonObjectPayload(t *testing.T) {
 	// Array payload — can't inject token, should return unchanged.
 	input := []byte(`[1,2,3]`)
@@ -60,4 +87,28 @@ func TestInjectToken_NonObjectPayload(t *testing.T) {
 			t.Fatalf("result is not valid JSON: %v", err)
 		}
 	}
+}
+
+func setupTokenInjectionTest(t *testing.T) {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("# test config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jety.SetConfigType("toml")
+	jety.SetConfigFile(configPath)
+
+	kp, err := nkeys.CreateAccount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := kp.Seed()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jety.Set("privkey", string(seed))
+	t.Cleanup(func() {
+		jety.Set("privkey", "")
+	})
 }

--- a/internal/api/client/nats.go
+++ b/internal/api/client/nats.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -130,10 +131,7 @@ func injectToken(data []byte) []byte {
 	// Inject token into existing JSON object by replacing the opening
 	// brace with an opening brace + token field. This avoids
 	// unmarshaling/remarshaling the entire payload.
-	trimmed := data
-	for len(trimmed) > 0 && trimmed[0] == ' ' {
-		trimmed = trimmed[1:]
-	}
+	trimmed := bytes.TrimLeft(data, " \t\r\n")
 	if len(trimmed) > 0 && trimmed[0] == '{' {
 		return append([]byte(fmt.Sprintf(`{"token":%s,`, tokenJSON)), trimmed[1:]...)
 	}


### PR DESCRIPTION
## Summary
- Treat all JSON whitespace before object payloads as ignorable when injecting CLI auth tokens
- Add a regression test using a real local test token for newline/tab-prefixed JSON payloads
- Bump Go to 1.26.6 and go-git to v5.19.2 to clear reachable govulncheck findings
- Pin CI lint/govulncheck jobs to the Go 1.26 line instead of floating to Go stable

## Tests
- go generate ./...
- go test -race ./...
- go vet ./...
- go build ./...
- staticcheck ./...
- govulncheck ./...
