### PR TITLE
fix(build): repair packaging paths and security drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ all-arches-farmer: farmer
 		go build -ldflags "-X main.GitCommit=$$GitCommit -X main.Tag=$$GitTag" -o "bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/"$$(printf $$GitTag)"/grlx-farmer" ./cmd/farmer/main.go &&\
 		printf "\e[32mSuccess!\e[39m\n" ;\
 		mkdir -p bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/latest ;\
-		cp bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/"$$(printf $$GitTag)"/farmer bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/latest/grlx-farmer ;\
+		cp bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/"$$(printf $$GitTag)"/grlx-farmer bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/latest/grlx-farmer ;\
 	done
 
 all-arches-sprout: sprout
@@ -89,7 +89,7 @@ all-arches-sprout: sprout
 		go build -ldflags "-X main.GitCommit=$$GitCommit -X main.Tag=$$GitTag" -o "bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/"$$(printf $$GitTag)"/grlx-sprout" ./cmd/sprout/*.go &&\
 		printf "\e[32mSuccess!\e[39m\n" ;\
 		mkdir -p bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/latest ;\
-		cp bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/"$$(printf $$GitTag)"/sprout bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/latest/grlx-sprout ;\
+		cp bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/"$$(printf $$GitTag)"/grlx-sprout bin/arches/"$$(printf $$GOOS)"/"$$(printf $$GOARCH)"/latest/grlx-sprout ;\
 	done
 
 all-arches-grlx: grlx
@@ -126,13 +126,13 @@ github: all-arches-farmer all-arches-sprout all-arches-grlx
 	mkdir -p bin/github
 	for arch in amd64 386 arm arm64 ; do \
 		export GitTag=$$(TAG=`git tag --contains $$(git rev-parse HEAD) | sort -R | tr '\n' ' '`; if [ "$$(printf "$$TAG")" ]; then printf "$$TAG"; else printf "undefined"; fi);\
-		cp bin/arches/linux/$$arch/$$(printf $$GitTag)/farmer bin/github/grlx-farmer-$$(printf $$GitTag)-linux-$$(printf $$arch);\
+		cp bin/arches/linux/$$arch/$$(printf $$GitTag)/grlx-farmer bin/github/grlx-farmer-$$(printf $$GitTag)-linux-$$(printf $$arch);\
 		tar -czf bin/github/grlx-farmer-$$(printf $$GitTag)-linux-$$(printf $$arch).tar.gz \
 	      -C bin/arches/linux/$$arch/$$(printf $$GitTag) grlx-farmer;\
 	done
 	for arch in amd64 386 arm arm64 ; do \
 		export GitTag=$$(TAG=`git tag --contains $$(git rev-parse HEAD) | sort -R | tr '\n' ' '`; if [ "$$(printf "$$TAG")" ]; then printf "$$TAG"; else printf "undefined"; fi);\
-		cp bin/arches/linux/$$arch/$$(printf $$GitTag)/sprout bin/github/grlx-sprout-$$(printf $$GitTag)-linux-$$(printf $$arch);\
+		cp bin/arches/linux/$$arch/$$(printf $$GitTag)/grlx-sprout bin/github/grlx-sprout-$$(printf $$GitTag)-linux-$$(printf $$arch);\
 		tar -czf bin/github/grlx-sprout-$$(printf $$GitTag)-linux-$$(printf $$arch).tar.gz \
 			-C bin/arches/linux/$$arch/$$(printf $$GitTag) grlx-sprout;\
 	done
@@ -161,11 +161,11 @@ clean:
 	docker rmi grlx/sprout:latest || true
 	docker rmi grlx/farmer:latest || true
 	rm -f ~/.config/grlx/tls-rootca.pem
-	rm -f main bin/grlx bin/farmer bin/sprout
+	rm -f main bin/grlx bin/grlx-farmer bin/grlx-sprout
 	rm -r bin/arches bin/github || true
 
 install: clean all
-	mv bin/grlx bin/farmer bin/sprout "$$GOPATH/bin/"
+	mv bin/grlx bin/grlx-farmer bin/grlx-sprout "$$GOPATH/bin/"
 
 docker:
 	docker build -t grlx/farmer . -f docker/farmer.dockerfile

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gogrlx/grlx/v2
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/mattn/go-localereader v0.0.1 => github.com/taigrr/go-localereader v0.0.2
 
@@ -57,7 +57,7 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.1 // indirect
-	github.com/go-git/go-git/v5 v5.19.1 // indirect
+	github.com/go-git/go-git/v5 v5.19.2 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/go-git/go-billy/v5 v5.9.1 h1:8U73XiOTfINdItHVa6z4Gv7ToObcZ6grkqQbLryL
 github.com/go-git/go-billy/v5 v5.9.1/go.mod h1:ExsU+jcGwXTBOnyilvAnEM1wug1IxHr4yP2ZXsNRtV0=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
-github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
+github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-logfmt/logfmt v0.6.1 h1:4hvbpePJKnIzH1B+8OR/JPbTx37NktoI9LE2QZBBkvE=
 github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/z6CO0XAk=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=


### PR DESCRIPTION
## Summary
- update release packaging copy paths to use the built grlx-farmer and grlx-sprout binary names
- update clean/install targets to match the binaries produced by the build targets
- bump the Go directive to 1.26.6 and go-git to v5.19.2 so govulncheck is clean

## Tests
- go generate ./...
- go test ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...
- govulncheck ./...
- make -n github
- git diff --check

Note: make all currently fails before packaging on Linux because internal/ingredients/service/rcd is BSD-only and excluded by build constraints.