### PR TITLE
fix(serve): preserve empty prop values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gogrlx/grlx/v2
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/mattn/go-localereader v0.0.1 => github.com/taigrr/go-localereader v0.0.2
 
@@ -57,7 +57,7 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.1 // indirect
-	github.com/go-git/go-git/v5 v5.19.1 // indirect
+	github.com/go-git/go-git/v5 v5.19.2 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/go-git/go-billy/v5 v5.9.1 h1:8U73XiOTfINdItHVa6z4Gv7ToObcZ6grkqQbLryL
 github.com/go-git/go-billy/v5 v5.9.1/go.mod h1:ExsU+jcGwXTBOnyilvAnEM1wug1IxHr4yP2ZXsNRtV0=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
-github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.2 h1:wkfn7vOlUBu8ivAWKBWisTiwJK4jYHzTF8Ndv1LyGqY=
+github.com/go-git/go-git/v5 v5.19.2/go.mod h1:QqCBE1EFN5ddFmrliLQ3/ntRCUjZU3EJuwuB/jWEHjk=
 github.com/go-logfmt/logfmt v0.6.1 h1:4hvbpePJKnIzH1B+8OR/JPbTx37NktoI9LE2QZBBkvE=
 github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/z6CO0XAk=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -332,21 +332,7 @@ func HandlePropsSetProxy(method string) http.HandlerFunc {
 		}
 		defer r.Body.Close()
 
-		var value string
-		if len(body) > 0 {
-			// Try to parse as {"value": "..."} first (web UI format).
-			var wrapper struct {
-				Value string `json:"value"`
-			}
-			if err := json.Unmarshal(body, &wrapper); err == nil && wrapper.Value != "" {
-				value = wrapper.Value
-			} else {
-				// Fall back to bare JSON string or raw text.
-				if err := json.Unmarshal(body, &value); err != nil {
-					value = string(body)
-				}
-			}
-		}
+		value := parsePropsSetValue(body)
 
 		params := map[string]string{"sprout_id": id, "name": key, "value": value}
 		result, err := client.NatsRequest(method, params)
@@ -358,6 +344,27 @@ func HandlePropsSetProxy(method string) http.HandlerFunc {
 		w.WriteHeader(http.StatusOK)
 		w.Write(result)
 	}
+}
+
+func parsePropsSetValue(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	// Try to parse as {"value": "..."} first (web UI format).
+	var wrapper struct {
+		Value *string `json:"value"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err == nil && wrapper.Value != nil {
+		return *wrapper.Value
+	}
+
+	// Fall back to bare JSON string or raw text.
+	var value string
+	if err := json.Unmarshal(body, &value); err != nil {
+		return string(body)
+	}
+	return value
 }
 
 // HandleCohortGetProxy returns a handler that forwards a cohort get request

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -694,6 +694,29 @@ func TestHandlePropsSetProxyFormats(t *testing.T) {
 	}
 }
 
+func TestParsePropsSetValue(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "empty body", body: "", want: ""},
+		{name: "wrapper", body: `{"value":"my-host"}`, want: "my-host"},
+		{name: "empty wrapper value", body: `{"value":""}`, want: ""},
+		{name: "bare json string", body: `"my-host"`, want: "my-host"},
+		{name: "raw text", body: `my-host`, want: "my-host"},
+		{name: "wrapper missing value falls back to raw", body: `{"other":"value"}`, want: `{"other":"value"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parsePropsSetValue([]byte(tt.body)); got != tt.want {
+				t.Fatalf("parsePropsSetValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHandlePropsSetProxyMissingParams(t *testing.T) {
 	handler := HandlePropsSetProxy("props.set")
 


### PR DESCRIPTION
## Summary
- Preserve explicit empty string values sent as {"value":""} to the local props API
- Extract prop-set request body parsing into a helper
- Add parser coverage for wrapper, empty wrapper, bare JSON string, raw text, and fallback shapes
- Bump go.mod to Go 1.26.6 and go-git to v5.19.2 so govulncheck clears current Go stdlib/go-git findings

## Validation
- curl -s https://go.dev/dl/?mode=json | jq -r '[0].version' -> go1.27.0
- go generate ./...
- GOTOOLCHAIN=auto go build ./...
- GOTOOLCHAIN=auto go vet ./...
- GOTOOLCHAIN=auto staticcheck ./...
- GOTOOLCHAIN=auto govulncheck ./...
- GOTOOLCHAIN=auto go test -race ./...
- GOTOOLCHAIN=auto go test ./internal/serve