### PR TITLE
feat(update): verify signed checksum manifests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.6
 replace github.com/mattn/go-localereader v0.0.1 => github.com/taigrr/go-localereader v0.0.2
 
 require (
+	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/fang v1.0.0
@@ -37,7 +38,6 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/antithesishq/antithesis-sdk-go v0.7.2 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/internal/update/noupdate.go
+++ b/internal/update/noupdate.go
@@ -11,11 +11,13 @@ import (
 
 // UpdateConfig holds the configuration for self-updates (no-op version)
 type UpdateConfig struct {
-	CurrentVersion string
-	BinaryName     string
-	ChecksumName   string
-	UpdateURL      string
-	CheckInterval  time.Duration
+	CurrentVersion     string
+	BinaryName         string
+	ChecksumName       string
+	UpdateURL          string
+	CheckInterval      time.Duration
+	TrustedPublicKey   string
+	TrustedFingerprint string
 }
 
 // Updater handles self-update functionality (no-op version)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -32,6 +33,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"golang.org/x/mod/semver"
 )
 
@@ -44,11 +46,13 @@ const maxLatestReleaseResponseBytes = 1 << 20
 
 // UpdateConfig holds the configuration for self-updates
 type UpdateConfig struct {
-	CurrentVersion string
-	BinaryName     string
-	ChecksumName   string
-	UpdateURL      string
-	CheckInterval  time.Duration
+	CurrentVersion     string
+	BinaryName         string
+	ChecksumName       string
+	UpdateURL          string
+	CheckInterval      time.Duration
+	TrustedPublicKey   string
+	TrustedFingerprint string
 }
 
 // Updater handles self-update functionality
@@ -206,6 +210,52 @@ func verifyArtifactChecksum(checksums io.Reader, artifact io.Reader, artifactNam
 	}
 
 	return nil
+}
+
+func verifyChecksumsSignature(publicKey, checksums, signature io.Reader, trustedFingerprint string) error {
+	keyring, err := openpgp.ReadArmoredKeyRing(publicKey)
+	if err != nil {
+		return fmt.Errorf("failed to read trusted update signing key: %w", err)
+	}
+
+	signer, err := openpgp.CheckDetachedSignature(keyring, checksums, signature, nil)
+	if err != nil {
+		return fmt.Errorf("failed to verify update checksums signature: %w", err)
+	}
+	if signer == nil || signer.PrimaryKey == nil {
+		return errors.New("update checksums signature did not identify a signing key")
+	}
+
+	if !fingerprintMatches(signer.PrimaryKey.Fingerprint[:], trustedFingerprint) {
+		return fmt.Errorf("update checksums were signed by unexpected key fingerprint %s", fingerprintString(signer.PrimaryKey.Fingerprint[:]))
+	}
+
+	return nil
+}
+
+func fingerprintMatches(actual []byte, expected string) bool {
+	expected = strings.Map(func(r rune) rune {
+		switch {
+		case r >= '0' && r <= '9':
+			return r
+		case r >= 'a' && r <= 'f':
+			return r
+		case r >= 'A' && r <= 'F':
+			return r + ('a' - 'A')
+		default:
+			return -1
+		}
+	}, expected)
+	if expected == "" {
+		return false
+	}
+
+	actualHex := fingerprintString(actual)
+	return subtle.ConstantTimeCompare([]byte(actualHex), []byte(expected)) == 1
+}
+
+func fingerprintString(fingerprint []byte) string {
+	return hex.EncodeToString(fingerprint)
 }
 
 func checksumForArtifact(checksums io.Reader, artifactName string) (string, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -4,8 +4,10 @@
 package selfupdate
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,6 +16,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 )
 
 func TestCheckForUpdatesUsesLatestReleaseSemver(t *testing.T) {
@@ -206,6 +211,73 @@ func TestVerifyArtifactChecksumRejectsMismatch(t *testing.T) {
 	}
 }
 
+func TestVerifyChecksumsSignatureAcceptsTrustedSigner(t *testing.T) {
+	t.Parallel()
+
+	publicKey, fingerprint, signature := testSignedChecksums(t, "checksum manifest")
+
+	err := verifyChecksumsSignature(
+		strings.NewReader(publicKey),
+		strings.NewReader("checksum manifest"),
+		bytes.NewReader(signature),
+		fingerprint,
+	)
+	if err != nil {
+		t.Fatalf("verifyChecksumsSignature returned error: %v", err)
+	}
+}
+
+func TestVerifyChecksumsSignatureRejectsTamperedChecksums(t *testing.T) {
+	t.Parallel()
+
+	publicKey, fingerprint, signature := testSignedChecksums(t, "checksum manifest")
+
+	err := verifyChecksumsSignature(
+		strings.NewReader(publicKey),
+		strings.NewReader("tampered manifest"),
+		bytes.NewReader(signature),
+		fingerprint,
+	)
+	if err == nil {
+		t.Fatal("verifyChecksumsSignature returned nil error for tampered checksums")
+	}
+	if !strings.Contains(err.Error(), "signature") {
+		t.Fatalf("verifyChecksumsSignature error = %q, want signature failure", err)
+	}
+}
+
+func TestVerifyChecksumsSignatureRejectsUnexpectedFingerprint(t *testing.T) {
+	t.Parallel()
+
+	publicKey, _, signature := testSignedChecksums(t, "checksum manifest")
+
+	err := verifyChecksumsSignature(
+		strings.NewReader(publicKey),
+		strings.NewReader("checksum manifest"),
+		bytes.NewReader(signature),
+		"3F62 7C68 8B72 ACC6 BC4C A9A7 1E0B 7A1D 33DC E4DD",
+	)
+	if err == nil {
+		t.Fatal("verifyChecksumsSignature returned nil error for unexpected signer")
+	}
+	if !strings.Contains(err.Error(), "unexpected key fingerprint") {
+		t.Fatalf("verifyChecksumsSignature error = %q, want unexpected fingerprint failure", err)
+	}
+}
+
+func TestFingerprintMatchesDocumentedFormat(t *testing.T) {
+	t.Parallel()
+
+	fingerprint, err := hex.DecodeString("3f627c688b72acc6bc4ca9a71e0b7a1d33dce4dd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !fingerprintMatches(fingerprint, "3F62 7C68 8B72 ACC6 BC4C A9A7 1E0B 7A1D 33DC E4DD") {
+		t.Fatal("fingerprintMatches rejected documented spaced uppercase fingerprint format")
+	}
+}
+
 func TestChecksumForArtifactRejectsMissingName(t *testing.T) {
 	t.Parallel()
 
@@ -213,6 +285,34 @@ func TestChecksumForArtifactRejectsMissingName(t *testing.T) {
 	if err == nil {
 		t.Fatal("checksumForArtifact returned nil error for missing artifact name")
 	}
+}
+
+func testSignedChecksums(t *testing.T, checksums string) (string, string, []byte) {
+	t.Helper()
+
+	entity, err := openpgp.NewEntity("grlx signing key", "", "security@grlx.dev", nil)
+	if err != nil {
+		t.Fatalf("NewEntity returned error: %v", err)
+	}
+
+	var publicKey bytes.Buffer
+	keyWriter, err := armor.Encode(&publicKey, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("armor.Encode returned error: %v", err)
+	}
+	if err := entity.Serialize(keyWriter); err != nil {
+		t.Fatalf("Serialize returned error: %v", err)
+	}
+	if err := keyWriter.Close(); err != nil {
+		t.Fatalf("closing armored public key returned error: %v", err)
+	}
+
+	var signature bytes.Buffer
+	if err := openpgp.DetachSign(&signature, entity, strings.NewReader(checksums), nil); err != nil {
+		t.Fatalf("DetachSign returned error: %v", err)
+	}
+
+	return publicKey.String(), fingerprintString(entity.PrimaryKey.Fingerprint[:]), signature.Bytes()
 }
 
 func TestChecksumForArtifactRejectsMissingChecksum(t *testing.T) {


### PR DESCRIPTION
## Summary
- add OpenPGP detached-signature verification for update checksum manifests
- pin accepted checksum signatures to the configured signing key fingerprint
- keep the no-update and self-update config shapes aligned across build tags

## Tests
- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...
- go test -tags self_update ./...

Refs #286