### PR TITLE
fix(jobs): remove sprout job metadata on reap

### DIFF
--- a/internal/jobs/sproutreaper.go
+++ b/internal/jobs/sproutreaper.go
@@ -66,6 +66,9 @@ func reapFlatDir(logDir string, ttl time.Duration) {
 				log.Errorf("sprout reaper: removing %s: %v", jobFile, rmErr)
 				continue
 			}
+			jobID := strings.TrimSuffix(entry.Name(), ".jsonl")
+			metaFile := filepath.Join(logDir, jobID+".meta.json")
+			os.Remove(metaFile)
 			removed++
 		}
 	}

--- a/internal/jobs/sproutreaper_test.go
+++ b/internal/jobs/sproutreaper_test.go
@@ -12,12 +12,20 @@ func TestReapFlatDirRemovesExpiredJobs(t *testing.T) {
 	dir := t.TempDir()
 
 	oldFile := filepath.Join(dir, "old-job.jsonl")
+	oldMetaFile := filepath.Join(dir, "old-job.meta.json")
 	newFile := filepath.Join(dir, "new-job.jsonl")
+	newMetaFile := filepath.Join(dir, "new-job.meta.json")
 
 	if err := os.WriteFile(oldFile, []byte(`{}`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(oldMetaFile, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(newFile, []byte(`{}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newMetaFile, []byte(`{}`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -26,14 +34,23 @@ func TestReapFlatDirRemovesExpiredJobs(t *testing.T) {
 	if err := os.Chtimes(oldFile, past, past); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chtimes(oldMetaFile, past, past); err != nil {
+		t.Fatal(err)
+	}
 
 	reapFlatDir(dir, 24*time.Hour)
 
 	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
 		t.Errorf("expected old-job.jsonl to be removed, but it still exists")
 	}
+	if _, err := os.Stat(oldMetaFile); !os.IsNotExist(err) {
+		t.Errorf("expected old-job.meta.json to be removed, but it still exists")
+	}
 	if _, err := os.Stat(newFile); err != nil {
 		t.Errorf("expected new-job.jsonl to still exist, got error: %v", err)
+	}
+	if _, err := os.Stat(newMetaFile); err != nil {
+		t.Errorf("expected new-job.meta.json to still exist, got error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove companion sprout job metadata files when expired flat job logs are reaped
- extend sprout reaper coverage for expired and fresh metadata files

## Tests
- go generate ./...
- go test ./internal/jobs
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...