### PR TITLE
fix(service): reject empty service names

### DIFF
--- a/internal/ingredients/service/service.go
+++ b/internal/ingredients/service/service.go
@@ -199,6 +199,9 @@ func (s Service) Parse(id, method string, properties map[string]interface{}) (co
 	switch nameI := nameI.(type) {
 	case string:
 		name = nameI
+		if name == "" {
+			return nil, ingredients.ErrMissingName
+		}
 	default:
 		return nil, ingredients.ErrMissingName
 	}

--- a/internal/ingredients/service/service_test.go
+++ b/internal/ingredients/service/service_test.go
@@ -52,6 +52,14 @@ func TestServiceParseNameNotString(t *testing.T) {
 	}
 }
 
+func TestServiceParseEmptyName(t *testing.T) {
+	s := Service{}
+	_, err := s.Parse("test-id", "running", map[string]interface{}{"name": ""})
+	if err != ingredients.ErrMissingName {
+		t.Errorf("expected ErrMissingName for empty name, got %v", err)
+	}
+}
+
 func TestServiceParseInvalidMethod(t *testing.T) {
 	s := Service{}
 	_, err := s.Parse("test-id", "nonexistent", map[string]interface{}{"name": "nginx"})


### PR DESCRIPTION
## Summary
- reject empty service ingredient names during top-level service parsing
- add a regression test for empty service names

## Tests
- go generate ./...
- go test -race ./internal/ingredients/service
- go test -race ./...
- go vet ./...
- staticcheck ./...
