### PR TITLE
fix(cook): report job log write failures

### DIFF
--- a/internal/cook/sproutcook.go
+++ b/internal/cook/sproutcook.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -206,19 +207,33 @@ func logStepResult(jobID string, completion StepCompletion) {
 		return
 	}
 	logFile := filepath.Join(config.JobLogDir, fmt.Sprintf("%s.jsonl", jobID))
-	b, err := json.Marshal(completion)
-	if err != nil {
-		log.Errorf("failed to marshal step completion for logging: %v", err)
-		return
-	}
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		log.Errorf("failed to open job log file %s: %v", logFile, err)
 		return
 	}
 	defer f.Close()
-	f.Write(b)
-	f.WriteString("\n")
+	if err := writeStepCompletionLogLine(f, completion); err != nil {
+		log.Errorf("failed to write step completion to job log %s: %v", logFile, err)
+	}
+}
+
+func writeStepCompletionLogLine(writer io.Writer, completion StepCompletion) error {
+	b, err := json.Marshal(completion)
+	if err != nil {
+		return fmt.Errorf("failed to marshal step completion for logging: %w", err)
+	}
+	if written, err := writer.Write(b); err != nil {
+		return fmt.Errorf("failed to write step completion: %w", err)
+	} else if written != len(b) {
+		return fmt.Errorf("failed to write step completion: %w", io.ErrShortWrite)
+	}
+	if written, err := writer.Write([]byte("\n")); err != nil {
+		return fmt.Errorf("failed to write step completion newline: %w", err)
+	} else if written != 1 {
+		return fmt.Errorf("failed to write step completion newline: %w", io.ErrShortWrite)
+	}
+	return nil
 }
 
 // RequisitesAreMet returns true if all of the requisites for the given step are met

--- a/internal/cook/sproutcook_test.go
+++ b/internal/cook/sproutcook_test.go
@@ -1,9 +1,68 @@
 package cook
 
 import (
+	"bytes"
 	"errors"
+	"io"
+	"strings"
 	"testing"
 )
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, io.ErrClosedPipe
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) {
+	return len(p) - 1, nil
+}
+
+func TestWriteStepCompletionLogLine(t *testing.T) {
+	var buf bytes.Buffer
+	completion := StepCompletion{
+		ID:               "step-one",
+		CompletionStatus: StepCompleted,
+		ChangesMade:      true,
+		Changes:          []string{"created file"},
+	}
+
+	if err := writeStepCompletionLogLine(&buf, completion); err != nil {
+		t.Fatalf("writeStepCompletionLogLine returned error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("expected JSONL output to end with newline, got %q", got)
+	}
+	if !strings.Contains(got, `"ID":"step-one"`) {
+		t.Fatalf("expected JSONL output to contain step ID, got %q", got)
+	}
+}
+
+func TestWriteStepCompletionLogLineReturnsWriteError(t *testing.T) {
+	err := writeStepCompletionLogLine(failingWriter{}, StepCompletion{
+		ID:               "step-one",
+		CompletionStatus: StepCompleted,
+	})
+
+	if !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("expected write error, got %v", err)
+	}
+}
+
+func TestWriteStepCompletionLogLineReturnsShortWrite(t *testing.T) {
+	err := writeStepCompletionLogLine(shortWriter{}, StepCompletion{
+		ID:               "step-one",
+		CompletionStatus: StepCompleted,
+	})
+
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("expected short write error, got %v", err)
+	}
+}
 
 func TestRequisitesAreMet(t *testing.T) {
 


### PR DESCRIPTION
## Summary

- report failures when writing cook step completions to JSONL job logs
- return and test write/short-write errors from the JSONL writer helper

## Tests

- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./internal/cook
- go test -race ./...
