### PR TITLE
fix(file): refresh mismatched local cache files

### DIFF
--- a/internal/ingredients/file/local/provider.go
+++ b/internal/ingredients/file/local/provider.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/gogrlx/grlx/v2/internal/ingredients/file"
 	"github.com/gogrlx/grlx/v2/internal/ingredients/file/hashers"
@@ -18,14 +19,14 @@ type LocalFile struct {
 	Props       map[string]interface{}
 }
 
+const downloadTempPattern = ".grlx-local-download-*"
+
 // Compile-time interface check.
 var _ file.FileProvider = LocalFile{}
 
 func (lf LocalFile) Download(ctx context.Context) error {
 	ok, err := lf.Verify(ctx)
-	// if verification failed because the file doesn't exist,
-	// that's ok. Otherwise, return the error.
-	if !errors.Is(err, file.ErrFileNotFound) {
+	if err != nil && !errors.Is(err, file.ErrFileNotFound) {
 		return err
 	}
 	// if the file exists and the hash matches, we're done.
@@ -38,15 +39,38 @@ func (lf LocalFile) Download(ctx context.Context) error {
 		return err
 	}
 	defer f.Close()
-	dest, err := os.Create(lf.Destination)
+	destinationDir := filepath.Dir(lf.Destination)
+	stagedFile, err := os.CreateTemp(destinationDir, downloadTempPattern)
 	if err != nil {
 		return err
 	}
-	_, err = io.Copy(dest, f)
-	dest.Close()
-	if err != nil {
+	stagedPath := stagedFile.Name()
+	cleanupStaged := true
+	defer func() {
+		if cleanupStaged {
+			os.Remove(stagedPath)
+		}
+	}()
+
+	_, copyErr := io.Copy(stagedFile, f)
+	closeErr := stagedFile.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	mode := os.FileMode(0o644)
+	if info, statErr := os.Stat(lf.Destination); statErr == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := os.Chmod(stagedPath, mode); err != nil {
 		return err
 	}
+	if err := os.Rename(stagedPath, lf.Destination); err != nil {
+		return err
+	}
+	cleanupStaged = false
 	_, err = lf.Verify(ctx)
 	return err
 }

--- a/internal/ingredients/file/local/provider_test.go
+++ b/internal/ingredients/file/local/provider_test.go
@@ -161,6 +161,49 @@ func TestDownloadSkipsWhenHashMatches(t *testing.T) {
 	}
 }
 
+func TestDownloadReplacesMismatchedDestination(t *testing.T) {
+	td := t.TempDir()
+	srcPath := filepath.Join(td, "source.txt")
+	dstPath := filepath.Join(td, "destination.txt")
+	sourceContent := []byte("fresh content")
+	staleContent := []byte("stale content")
+
+	if err := os.WriteFile(srcPath, sourceContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dstPath, staleContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := fmt.Sprintf("%x", md5.Sum(sourceContent))
+	lf := LocalFile{
+		ID:          "test-refresh",
+		Source:      srcPath,
+		Destination: dstPath,
+		Hash:        hash,
+		Props:       map[string]interface{}{"hashType": "md5"},
+	}
+
+	if err := lf.Download(context.Background()); err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+
+	got, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("failed to read destination: %v", err)
+	}
+	if string(got) != string(sourceContent) {
+		t.Fatalf("destination = %q, want %q", got, sourceContent)
+	}
+	info, err := os.Stat(dstPath)
+	if err != nil {
+		t.Fatalf("failed to stat destination: %v", err)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != 0600 {
+		t.Fatalf("destination mode = %v, want 0600", gotMode)
+	}
+}
+
 func TestDownloadSourceNotFound(t *testing.T) {
 	td := t.TempDir()
 	dstPath := filepath.Join(td, "destination.txt")


### PR DESCRIPTION
## Summary
- refresh local cached files when the destination hash does not match the requested source hash
- stage local provider copies through a temp file before rename, preserving existing destination permissions
- add regression coverage for stale local cache replacement

## Tests
- go generate ./...
- go test -race ./internal/ingredients/file/local ./internal/ingredients/file/...
- go vet ./internal/ingredients/file/local ./internal/ingredients/file/...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...