### PR TITLE
fix(file): handle long contains lines

### DIFF
--- a/internal/ingredients/file/fileAppend_test.go
+++ b/internal/ingredients/file/fileAppend_test.go
@@ -46,6 +46,10 @@ func TestAppend(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create file without content %s: %v", fileWithoutContent, err)
 	}
+	anotherFileWithoutContent := filepath.Join(tempDir, "there-is-another-file-without-content-here")
+	if err := os.WriteFile(anotherFileWithoutContent, nil, 0o644); err != nil {
+		t.Fatalf("failed to create file without content %s: %v", anotherFileWithoutContent, err)
+	}
 
 	fakePath := filepath.Join("/", "fakepath")
 
@@ -107,12 +111,12 @@ func TestAppend(t *testing.T) {
 		},
 		{
 			name:   "AppendFileWithoutContent",
-			params: map[string]interface{}{"name": fileWithoutContent, "text": "test"},
+			params: map[string]interface{}{"name": anotherFileWithoutContent, "text": "test"},
 			expected: cook.Result{
 				Succeeded: true,
 				Failed:    false,
 				Changed:   false,
-				Notes:     []fmt.Stringer{cook.Snprintf("file %s does not contain all specified content", fileWithoutContent), cook.Snprintf("appended to %s", fileWithoutContent)},
+				Notes:     []fmt.Stringer{cook.Snprintf("file %s does not contain all specified content", anotherFileWithoutContent), cook.Snprintf("appended to %s", anotherFileWithoutContent)},
 			},
 			error: nil,
 		},

--- a/internal/ingredients/file/fileContains.go
+++ b/internal/ingredients/file/fileContains.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -69,7 +68,7 @@ func (f File) contains(ctx context.Context, test bool) (cook.Result, bytes.Buffe
 	}
 
 	// Read current file contents.
-	file, err := os.Open(name)
+	fileContents, err := os.ReadFile(name)
 	if err != nil {
 		notes = append(notes, cook.Snprintf("failed to open %s", name))
 		return cook.Result{
@@ -77,19 +76,10 @@ func (f File) contains(ctx context.Context, test bool) (cook.Result, bytes.Buffe
 			Changed: false, Notes: notes,
 		}, content, err
 	}
-	currentContents := []string{}
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		currentContents = append(currentContents, scanner.Text())
-	}
-	file.Close()
+	currentContents := lines(fileContents)
 	sort.Strings(currentContents)
 
-	shouldContents := []string{}
-	scanner = bufio.NewScanner(&content)
-	for scanner.Scan() {
-		shouldContents = append(shouldContents, scanner.Text())
-	}
+	shouldContents := lines(content.Bytes())
 	sort.Strings(shouldContents)
 
 	isSubset, _ := stringSliceIsSubset(shouldContents, currentContents)
@@ -103,6 +93,23 @@ func (f File) contains(ctx context.Context, test bool) (cook.Result, bytes.Buffe
 		Succeeded: false, Failed: true,
 		Changed: false, Notes: notes,
 	}, content, ErrMissingContent
+}
+
+func lines(contents []byte) []string {
+	if len(contents) == 0 {
+		return nil
+	}
+
+	split := bytes.Split(contents, []byte("\n"))
+	if len(split) > 0 && len(split[len(split)-1]) == 0 {
+		split = split[:len(split)-1]
+	}
+
+	lines := make([]string, 0, len(split))
+	for _, line := range split {
+		lines = append(lines, string(line))
+	}
+	return lines
 }
 
 // gatherSourceBuf collects content from a single "source"/"source_hash" param pair into buf.

--- a/internal/ingredients/file/fileContains_test.go
+++ b/internal/ingredients/file/fileContains_test.go
@@ -2,9 +2,11 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gogrlx/grlx/v2/internal/config"
@@ -75,5 +77,34 @@ func TestContains(t *testing.T) {
 			}
 			compareResults(t, result, test.expected)
 		})
+	}
+}
+
+func TestContainsLongLine(t *testing.T) {
+	tempDir := t.TempDir()
+	target := filepath.Join(tempDir, "long-line")
+	existing := strings.Repeat("a", 70*1024)
+	missing := strings.Repeat("b", 70*1024)
+	if err := os.WriteFile(target, []byte(existing), 0o644); err != nil {
+		t.Fatalf("failed to write target: %v", err)
+	}
+
+	f := File{
+		id:     "long-line",
+		method: "contains",
+		params: map[string]interface{}{
+			"name": target,
+			"text": missing,
+		},
+	}
+	result, missingContent, err := f.contains(context.TODO(), false)
+	if !errors.Is(err, ErrMissingContent) {
+		t.Fatalf("expected ErrMissingContent, got %v", err)
+	}
+	if result.Succeeded || !result.Failed {
+		t.Fatalf("expected failed missing-content result, got %+v", result)
+	}
+	if got := missingContent.String(); got != missing {
+		t.Fatalf("expected missing long line to be preserved, got %d bytes", len(got))
 	}
 }


### PR DESCRIPTION
## Summary
- replace Scanner-based line splitting in file.contains with byte splitting so long lines are evaluated correctly
- add regression coverage for long-line missing content
- isolate an append test fixture so repeated cases do not share mutated state

## Tests
- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...