### PR TITLE
fix(service): publish method properties

### DIFF
--- a/internal/ingredients/service/service.go
+++ b/internal/ingredients/service/service.go
@@ -230,5 +230,13 @@ func (s Service) Methods() (string, []string) {
 }
 
 func (s Service) PropertiesForMethod(method string) (map[string]string, error) {
-	return nil, nil
+	switch method {
+	case "disabled", "enabled", "masked", "reloaded", "restarted", "running", "stopped", "unmasked":
+		return ingredients.MethodPropsSet{
+			ingredients.MethodProps{Key: "name", Type: "string", IsReq: true},
+			ingredients.MethodProps{Key: "userMode", Type: "bool", IsReq: false},
+		}.ToMap(), nil
+	default:
+		return nil, fmt.Errorf("method %s undefined", method)
+	}
 }

--- a/internal/ingredients/service/service_test.go
+++ b/internal/ingredients/service/service_test.go
@@ -103,12 +103,28 @@ func TestServiceProperties(t *testing.T) {
 
 func TestServicePropertiesForMethod(t *testing.T) {
 	s := Service{}
-	props, err := s.PropertiesForMethod("running")
-	if err != nil {
-		t.Errorf("PropertiesForMethod() returned error: %v", err)
+	for _, method := range []string{
+		"disabled", "enabled", "masked", "reloaded",
+		"restarted", "running", "stopped", "unmasked",
+	} {
+		props, err := s.PropertiesForMethod(method)
+		if err != nil {
+			t.Errorf("PropertiesForMethod(%q) returned error: %v", method, err)
+			continue
+		}
+		if props["name"] != "string,req" {
+			t.Errorf("PropertiesForMethod(%q)[name] = %q, want %q", method, props["name"], "string,req")
+		}
+		if props["userMode"] != "bool,opt" {
+			t.Errorf("PropertiesForMethod(%q)[userMode] = %q, want %q", method, props["userMode"], "bool,opt")
+		}
 	}
-	if props != nil {
-		t.Errorf("PropertiesForMethod() = %v, want nil", props)
+}
+
+func TestServicePropertiesForMethodInvalid(t *testing.T) {
+	s := Service{}
+	if _, err := s.PropertiesForMethod("nonexistent"); err == nil {
+		t.Fatal("PropertiesForMethod() expected error for invalid method")
 	}
 }
 


### PR DESCRIPTION
## Summary
- publish service method property metadata for all valid service methods
- include required name and optional systemd userMode metadata
- cover valid and invalid property lookup in service tests

## Validation
- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...