### PR TITLE
fix(file): parse decoded expected status codes

### DIFF
--- a/internal/ingredients/file/http/provider.go
+++ b/internal/ingredients/file/http/provider.go
@@ -2,11 +2,13 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	httpc "net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/gogrlx/grlx/v2/internal/ingredients/file"
 	"github.com/gogrlx/grlx/v2/internal/ingredients/file/hashers"
@@ -20,7 +22,12 @@ type HTTPFile struct {
 	Props       map[string]interface{}
 }
 
-const downloadTempPattern = ".grlx-http-download-*"
+const (
+	downloadTempPattern       = ".grlx-http-download-*"
+	expectedCodeProperty      = "expectedCode"
+	defaultExpectedStatusCode = httpc.StatusOK
+	maxExpectedStatusCode     = 999
+)
 
 // Compile-time interface check.
 var _ file.FileProvider = HTTPFile{}
@@ -44,12 +51,7 @@ func (hf HTTPFile) Download(ctx context.Context) error {
 		return err
 	}
 	defer res.Body.Close()
-	expectedCode := httpc.StatusOK
-	if hf.Props["expectedCode"] != nil {
-		if ec, okEC := hf.Props["expectedCode"].(int); okEC {
-			expectedCode = ec
-		}
-	}
+	expectedCode := expectedStatusCode(hf.Props)
 	if res.StatusCode != expectedCode {
 		// TODO standardize this error message
 		return fmt.Errorf("unexpected HTTP status code %d", res.StatusCode)
@@ -91,6 +93,66 @@ func (hf HTTPFile) Download(ctx context.Context) error {
 	}
 	cleanupStaged = false
 	return nil
+}
+
+func expectedStatusCode(props map[string]interface{}) int {
+	rawExpectedCode := props[expectedCodeProperty]
+	if rawExpectedCode == nil {
+		return defaultExpectedStatusCode
+	}
+
+	switch expectedCode := rawExpectedCode.(type) {
+	case int:
+		return expectedCode
+	case int8:
+		return int(expectedCode)
+	case int16:
+		return int(expectedCode)
+	case int32:
+		return int(expectedCode)
+	case int64:
+		return boundedStatusCode(expectedCode)
+	case uint:
+		return int(expectedCode)
+	case uint8:
+		return int(expectedCode)
+	case uint16:
+		return int(expectedCode)
+	case uint32:
+		return int(expectedCode)
+	case uint64:
+		if expectedCode <= maxExpectedStatusCode {
+			return int(expectedCode)
+		}
+	case float32:
+		return integralFloatStatusCode(float64(expectedCode))
+	case float64:
+		return integralFloatStatusCode(expectedCode)
+	case json.Number:
+		parsedCode, err := strconv.ParseInt(expectedCode.String(), 10, 64)
+		if err == nil {
+			return boundedStatusCode(parsedCode)
+		}
+	}
+
+	return defaultExpectedStatusCode
+}
+
+func boundedStatusCode(expectedCode int64) int {
+	if expectedCode >= 0 && expectedCode <= maxExpectedStatusCode {
+		return int(expectedCode)
+	}
+
+	return defaultExpectedStatusCode
+}
+
+func integralFloatStatusCode(expectedCode float64) int {
+	parsedCode := int(expectedCode)
+	if float64(parsedCode) == expectedCode && parsedCode >= 0 && parsedCode <= maxExpectedStatusCode {
+		return parsedCode
+	}
+
+	return defaultExpectedStatusCode
 }
 
 func applyRequestHeaders(req *httpc.Request, headers interface{}) error {

--- a/internal/ingredients/file/http/provider_test.go
+++ b/internal/ingredients/file/http/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -350,6 +351,52 @@ func TestDownloadCustomExpectedCode(t *testing.T) {
 	}
 	if string(data) != "accepted" {
 		t.Errorf("unexpected content: %s", data)
+	}
+}
+
+func TestDownloadCustomExpectedCodeFromDecodedNumber(t *testing.T) {
+	tests := []struct {
+		name         string
+		expectedCode interface{}
+	}{
+		{
+			name:         "float64",
+			expectedCode: float64(http.StatusAccepted),
+		},
+		{
+			name:         "json number",
+			expectedCode: json.Number("202"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusAccepted)
+				w.Write([]byte("accepted"))
+			}))
+			defer ts.Close()
+
+			td := t.TempDir()
+			hf := HTTPFile{
+				ID:          test.name,
+				Source:      ts.URL + "/accept",
+				Destination: filepath.Join(td, "out"),
+				Props: map[string]interface{}{
+					expectedCodeProperty: test.expectedCode,
+				},
+			}
+			if err := hf.Download(context.Background()); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			data, err := os.ReadFile(filepath.Join(td, "out"))
+			if err != nil {
+				t.Fatalf("failed to read output: %v", err)
+			}
+			if string(data) != "accepted" {
+				t.Errorf("unexpected content: %s", data)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- parse HTTP file provider expectedCode values from decoded numeric forms like float64 and json.Number
- centralize the expectedCode property name/default status handling
- add coverage for decoded numeric expectedCode values

## Tests
- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -tags self_update ./...
- go test -race ./...