### PR TITLE
fix(cmd): handle command start failures

### DIFF
--- a/internal/ingredients/cmd/cmdRun.go
+++ b/internal/ingredients/cmd/cmdRun.go
@@ -153,6 +153,11 @@ func (c Cmd) run(ctx context.Context, test bool) (cook.Result, error) {
 		result.Notes = append(result.Notes,
 			cook.SimpleNote(fmt.Sprintf("Command failed: %s", err.Error())))
 	}
+	if command.ProcessState == nil {
+		result.Succeeded = false
+		result.Failed = true
+		return result, nil
+	}
 	if command.ProcessState.ExitCode() != 0 {
 		result.Succeeded = false
 		result.Failed = true

--- a/internal/ingredients/cmd/cmdRun_test.go
+++ b/internal/ingredients/cmd/cmdRun_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -141,6 +142,38 @@ func TestRunSimpleCommand(t *testing.T) {
 	}
 	if strings.TrimSpace(output) != "hello" {
 		t.Errorf("expected 'hello', got %q", strings.TrimSpace(output))
+	}
+}
+
+func TestRunInvalidWorkingDirectoryFailsWithoutPanic(t *testing.T) {
+	c := Cmd{
+		id:     "test-invalid-cwd",
+		method: "run",
+		params: map[string]interface{}{
+			"name": "echo hello",
+			"cwd":  filepath.Join(t.TempDir(), "missing"),
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := c.run(ctx, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Failed || result.Succeeded {
+		t.Fatalf("expected failed result, got %+v", result)
+	}
+
+	var foundFailureNote bool
+	for _, note := range result.Notes {
+		if strings.HasPrefix(note.String(), "Command failed: ") {
+			foundFailureNote = true
+			break
+		}
+	}
+	if !foundFailureNote {
+		t.Fatalf("expected command failure note, got %+v", result.Notes)
 	}
 }
 


### PR DESCRIPTION
## Summary
- avoid nil ProcessState panics when a command fails before the process starts
- return a failed command result with the existing output/failure notes
- add regression coverage for an invalid working directory

## Tests
- go test ./...
- go test ./internal/ingredients/cmd
- go test -race ./internal/ingredients/cmd
- go build ./...
- go vet ./...
- staticcheck ./...
- go test -race ./...

Note: skipped go generate because this repo's generator runs rm -rf against the embedded web UI dist.