### PR TITLE
fix(sprout): reject malformed NATS requests

### DIFF
--- a/cmd/sprout/nats.go
+++ b/cmd/sprout/nats.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"runtime"
 
 	log "github.com/gogrlx/grlx/v2/internal/log"
 
-	apitypes "github.com/gogrlx/grlx/v2/internal/api/types"
 	"github.com/gogrlx/grlx/v2/internal/config"
 	"github.com/gogrlx/grlx/v2/internal/cook"
 	"github.com/gogrlx/grlx/v2/internal/facts"
@@ -15,6 +13,7 @@ import (
 	"github.com/gogrlx/grlx/v2/internal/ingredients/test"
 	"github.com/gogrlx/grlx/v2/internal/pki"
 	"github.com/gogrlx/grlx/v2/internal/shell"
+	"github.com/gogrlx/grlx/v2/internal/sproutnats"
 
 	nats "github.com/nats-io/nats.go"
 )
@@ -64,8 +63,13 @@ func natsInit(nc *nats.Conn) error {
 	}
 
 	_, err = nc.Subscribe("grlx.sprouts."+sproutID+".cmd.run", func(m *nats.Msg) {
-		var cmdRun apitypes.CmdRun
-		json.NewDecoder(bytes.NewBuffer(m.Data)).Decode(&cmdRun)
+		cmdRun, errorResponse, decodeErr := sproutnats.DecodeCmdRun(m.Data)
+		if decodeErr != nil {
+			log.Errorf("invalid cmd.run request: %v", decodeErr)
+			resultsB, _ := json.Marshal(errorResponse)
+			m.Respond(resultsB)
+			return
+		}
 		log.Trace(cmdRun)
 		results, err := cmd.SRun(cmdRun)
 		if err != nil {
@@ -81,8 +85,13 @@ func natsInit(nc *nats.Conn) error {
 		return err
 	}
 	_, err = nc.Subscribe("grlx.sprouts."+sproutID+".test.ping", func(m *nats.Msg) {
-		var ping apitypes.PingPong
-		json.NewDecoder(bytes.NewBuffer(m.Data)).Decode(&ping)
+		ping, errorResponse, decodeErr := sproutnats.DecodePing(m.Data)
+		if decodeErr != nil {
+			log.Errorf("invalid test.ping request: %v", decodeErr)
+			pongB, _ := json.Marshal(errorResponse)
+			m.Respond(pongB)
+			return
+		}
 		log.Trace(ping)
 		pong, _ := test.SPing(ping)
 		pongB, _ := json.Marshal(pong)
@@ -92,8 +101,13 @@ func natsInit(nc *nats.Conn) error {
 		return err
 	}
 	_, err = nc.Subscribe("grlx.sprouts."+sproutID+".cook", func(m *nats.Msg) {
-		var rEnvelope cook.RecipeEnvelope
-		json.NewDecoder(bytes.NewBuffer(m.Data)).Decode(&rEnvelope)
+		rEnvelope, errorResponse, decodeErr := sproutnats.DecodeCook(m.Data)
+		if decodeErr != nil {
+			log.Errorf("invalid cook request: %v", decodeErr)
+			ackB, _ := json.Marshal(errorResponse)
+			m.Respond(ackB)
+			return
+		}
 		log.Trace(rEnvelope)
 		ackB, _ := json.Marshal(cook.Ack{Acknowledged: true, JobID: rEnvelope.JobID})
 		m.Respond(ackB)

--- a/internal/sproutnats/decode.go
+++ b/internal/sproutnats/decode.go
@@ -1,0 +1,42 @@
+package sproutnats
+
+import (
+	"encoding/json"
+	"fmt"
+
+	apitypes "github.com/gogrlx/grlx/v2/internal/api/types"
+	"github.com/gogrlx/grlx/v2/internal/cook"
+)
+
+// DecodeCmdRun parses a sprout command request and returns a response-safe
+// failed command result when the payload is malformed.
+func DecodeCmdRun(data []byte) (apitypes.CmdRun, apitypes.CmdRun, error) {
+	var cmdRun apitypes.CmdRun
+	if err := json.Unmarshal(data, &cmdRun); err != nil {
+		return apitypes.CmdRun{}, apitypes.CmdRun{
+			Stderr:  fmt.Sprintf("invalid cmd.run request: %v", err),
+			ErrCode: -1,
+		}, err
+	}
+	return cmdRun, apitypes.CmdRun{}, nil
+}
+
+// DecodePing parses a sprout ping request and returns a negative pong response
+// when the payload is malformed.
+func DecodePing(data []byte) (apitypes.PingPong, apitypes.PingPong, error) {
+	var ping apitypes.PingPong
+	if err := json.Unmarshal(data, &ping); err != nil {
+		return apitypes.PingPong{}, apitypes.PingPong{Ping: false, Pong: false}, err
+	}
+	return ping, apitypes.PingPong{}, nil
+}
+
+// DecodeCook parses a sprout cook request and returns a negative ack when the
+// payload is malformed.
+func DecodeCook(data []byte) (cook.RecipeEnvelope, cook.Ack, error) {
+	var envelope cook.RecipeEnvelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return cook.RecipeEnvelope{}, cook.Ack{Acknowledged: false}, err
+	}
+	return envelope, cook.Ack{}, nil
+}

--- a/internal/sproutnats/decode_test.go
+++ b/internal/sproutnats/decode_test.go
@@ -1,0 +1,39 @@
+package sproutnats
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeCmdRunRejectsMalformedPayload(t *testing.T) {
+	_, response, err := DecodeCmdRun([]byte("{"))
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if response.ErrCode != -1 {
+		t.Fatalf("expected errcode -1, got %d", response.ErrCode)
+	}
+	if !strings.Contains(response.Stderr, "invalid cmd.run request") {
+		t.Fatalf("expected invalid request message, got %q", response.Stderr)
+	}
+}
+
+func TestDecodePingRejectsMalformedPayload(t *testing.T) {
+	_, response, err := DecodePing([]byte("{"))
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if response.Ping || response.Pong {
+		t.Fatalf("malformed ping should return false values, got %#v", response)
+	}
+}
+
+func TestDecodeCookRejectsMalformedPayload(t *testing.T) {
+	_, response, err := DecodeCook([]byte("{"))
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+	if response.Acknowledged {
+		t.Fatal("malformed cook request should not be acknowledged")
+	}
+}


### PR DESCRIPTION
## Summary
- reject malformed sprout cmd.run payloads before dispatching commands
- reject malformed test.ping and cook payloads before producing successful responses
- add sprout NATS handler coverage for malformed request payloads

## Tests
- go generate ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- go test ./...
- go test -race ./...