### PR TITLE
fix(file): return cached stat errors

### DIFF
--- a/internal/ingredients/file/fileCached.go
+++ b/internal/ingredients/file/fileCached.go
@@ -45,27 +45,31 @@ func (f File) cached(ctx context.Context, test bool) (cook.Result, error) {
 				Succeeded: true, Failed: false,
 				Changed: false, Notes: notes,
 			}, nil
-		} else {
-			if test {
-				notes = append(notes, cook.Snprintf("%s would be cached", cacheDest))
-				return cook.Result{
-					Succeeded: true, Failed: false,
-					Changed: true, Notes: notes,
-				}, nil
-			}
-			err = fp.Download(ctx)
-			if err != nil {
-				return cook.Result{
-					Succeeded: false, Failed: true,
-				}, err
-			}
-			notes = append(notes, cook.Snprintf("%s has been cached", cacheDest))
+		}
+		if !errors.Is(statErr, os.ErrNotExist) {
+			return cook.Result{
+				Succeeded: false, Failed: true,
+				Changed: false, Notes: notes,
+			}, statErr
+		}
+		if test {
+			notes = append(notes, cook.Snprintf("%s would be cached", cacheDest))
 			return cook.Result{
 				Succeeded: true, Failed: false,
 				Changed: true, Notes: notes,
 			}, nil
-
 		}
+		err = fp.Download(ctx)
+		if err != nil {
+			return cook.Result{
+				Succeeded: false, Failed: true,
+			}, err
+		}
+		notes = append(notes, cook.Snprintf("%s has been cached", cacheDest))
+		return cook.Result{
+			Succeeded: true, Failed: false,
+			Changed: true, Notes: notes,
+		}, nil
 	}
 	valid, errVal := fp.Verify(ctx)
 	if errVal != nil && !errors.Is(errVal, ErrFileNotFound) {

--- a/internal/ingredients/file/fileCached_test.go
+++ b/internal/ingredients/file/fileCached_test.go
@@ -2,9 +2,11 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -169,4 +171,41 @@ func TestCachedSkipVerify(t *testing.T) {
 	}
 	res, _ := f.cached(context.Background(), false)
 	compareResults(t, res, expected)
+}
+
+func TestCachedSkipVerifyReturnsStatErrors(t *testing.T) {
+	td := t.TempDir()
+	config.CacheDir = td
+	defer func() {
+		config.CacheDir = ""
+	}()
+
+	cacheDest := filepath.Join(td, "skip_dst")
+	if err := os.Symlink(cacheDest, cacheDest); err != nil {
+		t.Fatal(err)
+	}
+
+	f := File{
+		id:     "test",
+		method: "cached",
+		params: map[string]interface{}{
+			"name":        filepath.Join(td, "dst"),
+			"source":      tempFile,
+			"skip_verify": true,
+		},
+	}
+
+	res, err := f.cached(context.Background(), false)
+	if err == nil {
+		t.Fatal("expected stat error")
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected non-missing stat error, got %v", err)
+	}
+	compareResults(t, res, cook.Result{
+		Succeeded: false,
+		Failed:    true,
+		Changed:   false,
+		Notes:     []fmt.Stringer{},
+	})
 }


### PR DESCRIPTION
## Summary
- return non-missing `os.Stat` errors from `file.cached` when `skip_verify` is enabled
- preserve the existing missing-cache download/test behavior
- add a symlink-loop regression test for unexpected cache stat failures

## Validation
- `go generate ./...`
- `go test ./internal/ingredients/file/...`
- `go build ./...`
- `go vet ./...`
- `staticcheck ./...`
- `go test -race ./...`

Latest Go checked: `go1.27.1`; repo remains pinned to `go 1.26.2` for this focused fix.