### PR TITLE
fix(audit): allow large audit entries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v1.0.0 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/exp v0.0.0-20260820142414-ca536658362e // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260820142414-ca536658362e h1:01Ju2A/fZKkci4zqx0eZxw//DnRYOnBiGJG14hFBhO8=
 golang.org/x/exp v0.0.0-20260820142414-ca536658362e/go.mod h1:zeBbvyFKDaLwa7CH/zI8KXt7gTl14SF7sO08Pl5jBCM=
 golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=

--- a/internal/audit/query.go
+++ b/internal/audit/query.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const maxAuditEntryBytes = 1024 * 1024
+
 // QueryParams controls which audit entries to return.
 type QueryParams struct {
 	// Date filters entries to a specific date (YYYY-MM-DD).
@@ -71,6 +73,7 @@ func (l *Logger) Query(params QueryParams) (QueryResult, error) {
 
 	var all []Entry
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxAuditEntryBytes)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.TrimSpace(line) == "" {
@@ -169,6 +172,7 @@ func countLines(path string) int {
 
 	count := 0
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxAuditEntryBytes)
 	for scanner.Scan() {
 		if strings.TrimSpace(scanner.Text()) != "" {
 			count++

--- a/internal/audit/query_test.go
+++ b/internal/audit/query_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -317,6 +318,72 @@ not json at all
 	}
 	if result.Total != 2 {
 		t.Errorf("total = %d, want 2 (malformed line skipped)", result.Total)
+	}
+}
+
+func TestQueryLargeEntry(t *testing.T) {
+	dir := t.TempDir()
+	logger, err := NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	defer logger.Close()
+
+	largeParams := json.RawMessage(fmt.Sprintf(`{"payload":%q}`, strings.Repeat("x", 70*1024)))
+	writeTestEntries(t, logger, []Entry{
+		{Action: "large", Success: true, Parameters: largeParams},
+	})
+
+	result, err := logger.Query(QueryParams{Action: "large"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("total = %d, want 1", result.Total)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(result.Entries))
+	}
+	if string(result.Entries[0].Parameters) != string(largeParams) {
+		t.Error("large params payload was not preserved")
+	}
+}
+
+func TestListDatesCountsLargeEntries(t *testing.T) {
+	dir := t.TempDir()
+	today := time.Now().UTC().Format("2006-01-02")
+	path := filepath.Join(dir, "audit-"+today+".jsonl")
+
+	entry := Entry{
+		Timestamp:  time.Now().UTC(),
+		Action:     "large",
+		Success:    true,
+		Parameters: json.RawMessage(fmt.Sprintf(`{"payload":%q}`, strings.Repeat("x", 70*1024))),
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o640); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	logger, err := NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	defer logger.Close()
+
+	dates, err := logger.ListDates()
+	if err != nil {
+		t.Fatalf("ListDates: %v", err)
+	}
+	if len(dates) != 1 {
+		t.Fatalf("dates = %d, want 1", len(dates))
+	}
+	if dates[0].EntryCount != 1 {
+		t.Errorf("entry_count = %d, want 1", dates[0].EntryCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- raise the audit JSONL scanner token limit to handle larger audit records
- cover large audit entries in query and date-summary tests
- bump golang.org/x/crypto to v0.56.0 to clear the SSH DoS govulncheck findings

## Tests
- go test ./internal/audit
- go test ./...
- go build ./...
- go vet ./...
- staticcheck ./...
- govulncheck ./...
- go test -race ./...

## Notes
- go generate ./... still fails on master in grlx-web-ui TypeScript tests; PR #326 already covers that generated UI path.